### PR TITLE
Add BGPT MCP to bio category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -463,6 +463,15 @@ projects:
       - cloud
       - local
     category: art-and-culture
+  - name: connerlambden/bgpt-mcp
+    github_id: connerlambden/bgpt-mcp
+    description: >-
+      Search scientific papers with structured experimental data extracted from
+      full-text studies. Returns 25+ fields per paper including methods, results,
+      sample sizes, limitations, and quality scores.
+    labels:
+      - cloud
+    category: bio
   - name: genomoncology/biomcp
     github_id: genomoncology/biomcp
     description: >-


### PR DESCRIPTION
Adds BGPT MCP API to the `bio` (Biology Medicine and Bioinformatics) category in `projects.yaml`.

**BGPT MCP API** — Search scientific papers with structured experimental data extracted from full-text studies. Returns 25+ fields per paper including methods, results, sample sizes, limitations, and quality scores.

- GitHub: https://github.com/connerlambden/bgpt-mcp
- Website: https://bgpt.pro/mcp
- Transport: SSE
- Pricing: 50 free searches, then $0.01/result