### PR TITLE
Add project: Human Pages

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4051,3 +4051,14 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+  - name: human-pages-ai/humanpages
+    github_id: human-pages-ai/humanpages
+    npm_id: humanpages
+    description: >-
+      Search for and hire humans for real-world tasks. 31 tools for AI agents
+      to browse profiles by skill/location, post jobs, message workers, and
+      handle streaming payments via humanpages.ai.
+    labels:
+      - cloud
+      - typescript
+    category: workplace-and-productivity


### PR DESCRIPTION
Adds [Human Pages](https://github.com/human-pages-ai/humanpages) — an MCP server that enables AI agents to search for and hire humans for real-world tasks via humanpages.ai.

- **npm**: `humanpages`
- **31 tools**: profile search by skill/location/equipment, job offers, job board listings, in-job messaging, streaming payments
- **Transports**: stdio (`npx humanpages`) and remote HTTP (`https://humanpages.ai/mcp`)
- **Pricing**: Free tier, Pro ($5 USDC), and x402 pay-per-use
- **License**: MIT