### PR TITLE
Add LastSaaS Admin MCP Server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4051,3 +4051,13 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+  - name: LastSaaS
+    github_id: jonradoff/lastsaas
+    description: >-
+      MCP server for SaaS administration. Manage users, subscriptions, billing
+      (Stripe), system logs, and multi-tenant operations through natural
+      language. Built with Go and React.
+    labels:
+      - go
+      - cloud
+    category: developer-tools


### PR DESCRIPTION
## Summary
- Add [LastSaaS](https://github.com/jonradoff/lastsaas) to the **Developer Tools** category
- LastSaaS is an MCP server for SaaS administration — manage users, subscriptions, Stripe billing, system logs, and multi-tenant operations through natural language
- Built with Go (backend) and React (frontend)

## Details
- **Category**: developer-tools
- **Labels**: go, cloud
- **GitHub**: jonradoff/lastsaas