### PR TITLE
Add commune-sh/commune-mcp to communication category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1114,8 +1114,8 @@ projects:
       - local
       - typescript
     category: communication
-  - name: commune-sh/commune-mcp
-    github_id: commune-sh/commune-mcp
+  - name: shanjairaj7/commune-mcp
+    github_id: shanjairaj7/commune-mcp
     description: >-
       Email infrastructure for AI agents — provision inboxes, send and receive
       email, manage threads across concurrent conversations, custom domains,

--- a/projects.yaml
+++ b/projects.yaml
@@ -1114,6 +1114,16 @@ projects:
       - local
       - typescript
     category: communication
+  - name: commune-sh/commune-mcp
+    github_id: commune-sh/commune-mcp
+    description: >-
+      Email infrastructure for AI agents — provision inboxes, send and receive
+      email, manage threads across concurrent conversations, custom domains,
+      structured extraction on inbound mail, and SMS.
+    labels:
+      - cloud
+      - python
+    category: communication
   - name: antvis/mcp-server-chart
     github_id: antvis/mcp-server-chart
     description:


### PR DESCRIPTION
Adding Commune MCP to the communication category in projects.yaml.

It's agent-native email infrastructure — handles inbox provisioning, send/receive, thread tracking across concurrent conversations, custom domains, structured extraction on inbound mail, and SMS. The key differentiator from other email entries in this list is that it's built for agents creating and managing their own email identities, not for wrapping a human's Gmail account.