### PR TITLE
Add agentic-ads to Marketing category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2821,6 +2821,17 @@ projects:
       - cloud
       - python
     category: marketing
+  - name: nicofains1/agentic-ads
+    github_id: nicofains1/agentic-ads
+    npm_id: agentic-ads
+    description: >-
+      Ad network for AI agents. MCP servers embed a search_ads() call to surface
+      sponsored recommendations alongside organic results, earning affiliate
+      commissions paid in USDC on Base. Publishers earn 70% of ad revenue.
+    labels:
+      - cloud
+      - typescript
+    category: marketing
   - name: open-strategy-partners/osp_marketing_tools
     github_id: open-strategy-partners/osp_marketing_tools
     description: >-


### PR DESCRIPTION
## Summary

Adds [agentic-ads](https://github.com/nicofains1/agentic-ads) to the **Marketing** category.

**agentic-ads** is an ad network for AI agents — MCP servers embed a `search_ads()` call to surface sponsored recommendations alongside organic results, earning affiliate commissions paid in USDC on Base. Publishers earn 70% of ad revenue.

- **npm**: [agentic-ads](https://www.npmjs.com/package/agentic-ads)
- **Remote MCP endpoint**: https://agentic-ads-production.up.railway.app/mcp
- **MCP Registry**: `io.github.nicofains1/agentic-ads`
- **Language**: TypeScript
- **Deployment**: Cloud (hosted)
- **270 tests passing**, live production deployment on Railway

Happy to adjust the category or description if needed.