### PR TITLE
Add newsmcp — real-time world news MCP server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4051,3 +4051,14 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+  - name: pranciskus/newsmcp
+    github_id: pranciskus/newsmcp
+    npm_id: "@newsmcp/server"
+    description: >-
+      Real-time world news for AI agents — events clustered from hundreds of
+      sources, classified by 12 topics and 30+ geographic regions, ranked by
+      importance. Free, no API key required.
+    labels:
+      - cloud
+      - typescript
+    category: search-data-extraction


### PR DESCRIPTION
Adds [newsmcp](https://github.com/pranciskus/newsmcp) to the **Search & Data Extraction** category.

Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.

- **npm**: [@newsmcp/server](https://www.npmjs.com/package/@newsmcp/server)
- **Website**: [newsmcp.io](https://newsmcp.io)