### PR TITLE
Add Monolith — Unreal Engine 5.7 MCP Plugin

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2613,6 +2613,17 @@ projects:
       - cloud
       - python
     category: gaming
+  - name: tumourlove/monolith
+    github_id: tumourlove/monolith
+    description: >-
+      Unreal Engine 5.7 editor plugin that gives AI assistants full read/write
+      access to Blueprints, Materials, Animation, Niagara, Config, Editor,
+      Project Index, and Engine Source via MCP. 119 actions across 9 domains.
+      Pure C++, embedded Streamable HTTP server, no Python bridges.
+    labels:
+      - local
+      - cpp
+    category: gaming
   - name: 0xshellming/mcp-summarizer
     github_id: 0xshellming/mcp-summarizer
     description: >-


### PR DESCRIPTION
Adds Monolith to the gaming category.

**Monolith** is an Unreal Engine 5.7 editor plugin that exposes 119 MCP actions across 9 domains (Blueprints, Materials, Animation, Niagara, Editor, Config, Project Index, Engine Source). Pure C++, embedded Streamable HTTP server, namespace dispatch pattern.

GitHub: https://github.com/tumourlove/monolith
License: MIT