### PR TITLE
Add Lightning Wallet MCP to Finance & Fintech

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2750,6 +2750,14 @@ projects:
       - cloud
       - python
     category: finance-and-fintech
+  - name: Lightning Wallet MCP
+    github_id: lightningfaucet/lightning-wallet-mcp
+    npm_id: lightning-wallet-mcp
+    description: Give AI agents a Bitcoin wallet with Lightning Network payments and L402 support
+    labels:
+      - cloud
+      - typescript
+    category: finance-and-fintech
   - name: mcpdotdirect/evm-mcp-server
     github_id: mcpdotdirect/evm-mcp-server
     description: >-


### PR DESCRIPTION
## Summary

Adds [Lightning Wallet MCP](https://github.com/lightningfaucet/lightning-wallet-mcp) to the Finance & Fintech category.

Lightning Wallet MCP gives AI agents a Bitcoin wallet with Lightning Network payments and L402 (HTTP 402) support. Published on npm as `lightning-wallet-mcp`.

## Entry added

```yaml
- name: Lightning Wallet MCP
  github_id: lightningfaucet/lightning-wallet-mcp
  npm_id: lightning-wallet-mcp
  description: Give AI agents a Bitcoin wallet with Lightning Network payments and L402 support
  labels:
    - cloud
    - typescript
  category: finance-and-fintech
```