### PR TITLE
Add DSers MCP Product with new Dropshipping category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -54,6 +54,9 @@ categories:
   - category: developer-tools
     title: Developer Tools
     subtitle: MCP servers for developer tools
+  - category: dropshipping
+    title: Dropshipping
+    subtitle: MCP servers for dropshipping automation and e-commerce product import
   - category: embedded-system
     title: Embedded System
     subtitle: MCP servers for embedded system
@@ -4492,3 +4495,15 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+  - name: lofder/dsers-mcp-product
+    github_id: lofder/dsers-mcp-product
+    npm_id: "@lofder/dsers-mcp-product"
+    description: >-
+      Automate AliExpress/Alibaba dropshipping product import to Shopify or Wix
+      via DSers. Bulk import, variant editing, pricing rules, and multi-store
+      push with a single MCP command.
+    labels:
+      - typescript
+      - cloud
+      - local
+    category: dropshipping


### PR DESCRIPTION
## New Server + New Category

Adds **DSers MCP Product** and introduces a new **Dropshipping** category.

### Server Details
- **Repository**: https://github.com/lofder/dsers-mcp-product
- **npm**: `@lofder/dsers-mcp-product`
- **Language**: TypeScript
- **Labels**: typescript, cloud, local

### Description
Automate AliExpress/Alibaba dropshipping product import to Shopify or Wix via DSers. Bulk import, variant editing, pricing rules, and multi-store push with a single MCP command.

### Why a new category?
There is currently no category for dropshipping or e-commerce product import automation. The "Dropshipping" category fills this gap as MCP adoption grows in the e-commerce space.