### PR TITLE
Add project: Reporecall

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -3045,6 +3045,16 @@ projects:
       - typescript
       - windows
     category: knowledge-and-memory
+  - name: Reporecall
+    github_id: proofofwork-agency/reporecall
+    npm_id: reporecall
+    description: >-
+      Local codebase memory for Claude Code and MCP clients. AST indexing
+      (22 languages), call graph expansion, hybrid keyword + vector search.
+    labels:
+      - local
+      - typescript
+    category: knowledge-and-memory
   - name: ragieai/ragie-mcp-server
     github_id: ragieai/ragie-mcp-server
     description: >-


### PR DESCRIPTION
## What it does

[Reporecall](https://github.com/proofofwork-agency/reporecall) gives Claude Code a codebase memory so it stops wasting tokens rediscovering your code.

**The problem:** Claude Code spends its first moves grepping and reading files to understand a codebase it's already seen. On large repos this burns through context window and token budget before real work starts.

**The solution:** Reporecall pre-indexes your codebase using Tree-sitter AST parsing (22 languages), builds call graphs, and injects relevant context via a hook in ~5ms — before Claude starts thinking. No grep chains, no exploration loops.

- Hybrid keyword + vector search
- Call graph traversal (callers + callees)
- Also works as an MCP server
- 3-8x reduction in token usage for context gathering

npm: `@proofofwork-agency/reporecall`