### PR TITLE
Add project: Global Chat MCP Server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -348,6 +348,18 @@ projects:
       - cloud
       - local
     category: aggregators
+  - name: pumanitro/global-chat
+    github_id: pumanitro/global-chat
+    npm_id: "@global-chat/mcp-server"
+    description: >-
+      Cross-protocol AI agent discovery platform. MCP server providing
+      searchable directory of 18K+ servers across 6+ registries, with a free
+      agents.txt validator.
+    labels:
+      - typescript
+      - cloud
+      - local
+    category: aggregators
   - name: TheLunarCompany/lunar
     github_id: TheLunarCompany/lunar
     description: >-


### PR DESCRIPTION
Adds [Global Chat](https://github.com/pumanitro/global-chat) to the **Aggregators** category.

**Global Chat** is a cross-protocol AI agent discovery platform that provides:
- An MCP server ([`@global-chat/mcp-server`](https://www.npmjs.com/package/@global-chat/mcp-server)) with a searchable directory of 18K+ MCP servers across 6+ registries
- A free agents.txt validator/linter
- Protocol-agnostic agent discovery across MCP, A2A, agents.txt, ACDP, and more

Website: https://global-chat.io