### PR TITLE
Add Markgatcha/universal-mcp-toolkit to Aggregators

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -180,7 +180,7 @@ labels:
       For Linux
 
 projects:
-  - name: 1mcp-app/agent
+  - name: Markgatcha/universal-mcp-toolkit   github_id: Markgatcha/universal-mcp-toolkit   description: >-     All-in-one MCP toolkit that bundles 15+ servers into a single package — filesystem,     browser automation, GitHub, weather, web search, and more. Zero config needed: just     run `npx universal-mcp-toolkit` and everything's set up instantly. Listed on Glama.   labels:     - cloud     - linux     - local     - macos     - typescript     - windows   category: aggregators - name: 1mcp-app/agent
     github_id: 1mcp-app/agent
     description: >-
       A unified Model Context Protocol server implementation that aggregates


### PR DESCRIPTION
Hey! I'd like to add [universal-mcp-toolkit](https://github.com/Markgatcha/universal-mcp-toolkit) to the Aggregators section.

It's an all-in-one MCP toolkit that bundles 15+ servers into a single package — filesystem, browser automation, GitHub, weather, web search, and more. Zero config needed: just run `npx universal-mcp-toolkit` and everything's set up instantly.

It's listed on Glama and has 100+ npm downloads. Since it aggregates multiple MCP servers into a single unified endpoint, the Aggregators category seems like the right fit.

Let me know if you'd prefer a different category or need any changes!

**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category