### PR TITLE
Add DexPaprika MCP and CoinPaprika MCP to Finance & Fintech

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2856,6 +2856,18 @@ projects:
     labels:
       - cloud
     category: finance-and-fintech
+  - name: coinpaprika/dexpaprika-mcp
+    github_id: coinpaprika/dexpaprika-mcp
+    description: Real-time DEX data across 34 blockchains. 30M+ pools, 27M+ tokens, OHLCV, trades. Free, no API key, no rate limits.
+    labels:
+      - cloud
+    category: finance-and-fintech
+  - name: coinpaprika/coinpaprika-mcp
+    github_id: coinpaprika/coinpaprika-mcp
+    description: Crypto market data for 12,000+ coins and 350+ exchanges. Tickers, OHLCV, historical prices, contract lookups. Free, no API key.
+    labels:
+      - cloud
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:

--- a/projects.yaml
+++ b/projects.yaml
@@ -2859,8 +2859,8 @@ projects:
   - name: coinpaprika/dexpaprika-mcp
     github_id: coinpaprika/dexpaprika-mcp
     description: >-
-      DEX data across 36 blockchains. 36M+ pools, 33M+ tokens, 230+ DEXes, OHLCV,
-      trades and SSE streaming. Free tier, no API key required.
+      DEX data across 36 blockchains. 36M+ pools, 33M+ tokens, 230+ DEXes,
+      OHLCV, trades and SSE streaming. Free tier, no API key required.
     labels:
       - cloud
     category: finance-and-fintech

--- a/projects.yaml
+++ b/projects.yaml
@@ -2858,13 +2858,17 @@ projects:
     category: finance-and-fintech
   - name: coinpaprika/dexpaprika-mcp
     github_id: coinpaprika/dexpaprika-mcp
-    description: Real-time DEX data across 34 blockchains. 30M+ pools, 27M+ tokens, OHLCV, trades. Free, no API key, no rate limits.
+    description: >-
+      DEX data across 36 blockchains. 36M+ pools, 33M+ tokens, 230+ DEXes, OHLCV,
+      trades and SSE streaming. Free tier, no API key required.
     labels:
       - cloud
     category: finance-and-fintech
   - name: coinpaprika/coinpaprika-mcp
     github_id: coinpaprika/coinpaprika-mcp
-    description: Crypto market data for 12,000+ coins and 350+ exchanges. Tickers, OHLCV, historical prices, contract lookups. Free, no API key.
+    description: >-
+      Crypto market data for 12,000+ coins and 350+ exchanges. Tickers, OHLCV,
+      historical prices and contract lookups. Free tier, no API key required.
     labels:
       - cloud
     category: finance-and-fintech


### PR DESCRIPTION
Adds two crypto data MCP servers to the Finance & Fintech category:

- **DexPaprika MCP**: DEX data across 36 chains. 36M+ pools, 33M+ tokens, 230+ DEXes, plus OHLCV, trades and SSE streaming.
- **CoinPaprika MCP**: 12,000+ coins and 350+ exchanges. Tickers, OHLCV, historical prices and contract lookups.

Both start keyless on a free tier, so they work in an MCP client with no signup step, and both free tiers are metered. Current limits: https://dexpaprika.com/api/pricing and https://coinpaprika.com/api/pricing

I tagged both `cloud` because each also runs as a hosted server (mcp.dexpaprika.com, mcp.coinpaprika.com) alongside the npm build.
