### PR TITLE
Add PreReason/mcp to Finance & Fintech category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2856,6 +2856,17 @@ projects:
     labels:
       - cloud
     category: finance-and-fintech
+  - name: PreReason/mcp
+    github_id: PreReason/mcp
+    description:
+      Financial market context API delivering pre-analyzed briefings with trend
+      signals, regime classification, and confidence scores. 17 briefings
+      covering BTC on-chain, macro indicators, and cross-asset correlations.
+      Markdown-first output for efficient LLM token usage.
+    labels:
+      - cloud
+      - typescript
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
Adds PreReason/mcp to the projects.yaml under Finance & Fintech.

PreReason is a financial market context API serving pre-analyzed briefings through MCP. It covers BTC on-chain data, macro indicators, and cross-asset correlations with trend signals and regime classification. Output is markdown-first for efficient LLM consumption.

- GitHub: [PreReason/mcp](https://github.com/PreReason/mcp)
- npm: [@prereason/mcp](https://www.npmjs.com/package/@prereason/mcp)
- License: MIT