### PR TITLE
Add DunkelCloud/ToolMesh to projects.yaml

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -193,6 +193,19 @@ projects:
       - typescript
       - windows
     category: aggregators
+  - name: DunkelCloud/ToolMesh
+    github_id: DunkelCloud/ToolMesh
+    description: >-
+      Self-hosted MCP gateway with authorization (OpenFGA), credential injection,
+      audit logging, and output policies. REST APIs are declared in YAML via DADL
+      and exposed as MCP tools without custom server code.
+    labels:
+      - go
+      - cloud
+      - linux
+      - macos
+      - windows
+    category: aggregators
   - name: mcpjungle/MCPJungle
     github_id: mcpjungle/MCPJungle
     description: Self-hosted MCP Server registry for enterprise AI Agents


### PR DESCRIPTION
Add DunkelCloud/ToolMesh project with details and labels.

**What kind of change does this PR introduce?**
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**
ToolMesh is an Apache-2.0, self-hosted MCP gateway in Go that enforces authorization, server-side credential injection, audit logging, and output policies on every tool call. With DADL, REST APIs are declared in YAML and exposed as MCP tools without writing custom MCP servers.

**Checklist:**
<!--- Before you submit the PR, go over this checklist and make sure you can
tick off all the boxes. [] -> [x] -->

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
