### PR TITLE
Add CompanyScope MCP - company intelligence server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -3617,6 +3617,17 @@ projects:
       - windows
       - linux
     category: search-data-extraction
+  - name: Stewyboy1990/companyscope-mcp
+    github_id: Stewyboy1990/companyscope-mcp
+    description: >-
+      Company intelligence MCP server that returns a full company profile from a
+      single tool call. Aggregates data from 8 free public sources including
+      Wikipedia, GitHub, SEC EDGAR, RDAP, and web scraping. No API keys required.
+      Available as both a remote MCP server and an Apify Actor.
+    labels:
+      - typescript
+      - cloud
+    category: search-data-extraction
   - name: mariocandela/beelzebub
     github_id: mariocandela/beelzebub
     description: >-


### PR DESCRIPTION
## New Server: CompanyScope MCP

**Repository:** https://github.com/Stewyboy1990/companyscope-mcp
**Category:** Search & Data Extraction

### Description

CompanyScope is a company intelligence MCP server that returns a full company profile from a single tool call. It aggregates data from 8 free public sources:

- **Wikipedia/Wikidata** — company overview, founding info, leadership
- **GitHub** — repositories, tech stack, developer activity
- **SEC EDGAR** — financials, SEC filings, stock tickers (US public companies)
- **RDAP** — domain registration, registrar, nameservers
- **Web scraping** — homepage metadata, tech stack detection
- **OpenCorporates** — corporate registry data
- **Hunter.io** — email patterns, key people
- **NewsAPI** — recent news articles

No API keys required for the core 5 sources. Available as a remote MCP server and an Apify Actor.

### Tools provided
- `lookup_company` — Full company intelligence profile
- `get_tech_stack` — Technology stack analysis
- `get_corporate_registry` — Corporate registration data
- `get_key_people` — Key people and leadership
- `get_company_news` — Recent news and updates
- `get_financials` — SEC EDGAR financial data