### PR TITLE
Add webaesbyamin/agent-receipts — cryptographic receipts for AI agents

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -3816,6 +3816,14 @@ projects:
       - windows
       - linux
     category: security
+  - name: webaesbyamin/agent-receipts
+    github_id: webaesbyamin/agent-receipts
+    description: >-
+      Cryptographic accountability for AI agents. Ed25519-signed receipts for
+      every MCP tool call with SHA-256 content hashing, constraint evaluation,
+      receipt chains, AI judgment, invoicing, and a local dashboard.
+    labels: []
+    category: security
   - name: HagaiHen/facebook-mcp-server
     github_id: HagaiHen/facebook-mcp-server
     description: >-


### PR DESCRIPTION
Adds [agent-receipts](https://github.com/webaesbyamin/agent-receipts) to the security category.

Ed25519-signed receipts for every MCP tool call — SHA-256 content hashing, constraint evaluation, receipt chains, AI judgment, invoicing, and a local dashboard.

Published on npm as `@agent-receipts/mcp-server`.