### PR TITLE
Add ida-hive and x64dbg-hive (native RE MCP servers)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4492,3 +4492,15 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+  - name: yynps737/ida-hive
+    github_id: yynps737/ida-hive
+    description: >-
+      Native multi-instance IDA Pro MCP server (Rust + C++). 60 AI tools, up to
+      100 concurrent analysis sessions via idalib headless. Zero Python dependency.
+    category: security
+  - name: yynps737/x64dbg-hive
+    github_id: yynps737/x64dbg-hive
+    description: >-
+      Native x64dbg MCP server (C++ plugin + Rust). 92 AI debugging tools covering
+      disassembly, breakpoints, memory, registers, tracing, anti-debug, PE analysis.
+    category: security


### PR DESCRIPTION
Adds two native reverse engineering MCP servers to the security category:
- **ida-hive** — Multi-instance IDA Pro server (Rust + C++), 60 tools
- **x64dbg-hive** — x64dbg debugger server (C++ plugin + Rust), 92 tools