### PR TITLE
Add useful-ai/useful-ai-mcp to developer-tools

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2481,6 +2481,17 @@ projects:
       - typescript
       - local
     category: developer-tools
+  - name: useful-ai/useful-ai-mcp
+    github_id: useful-ai/useful-ai-mcp
+    homepage: https://api.usefulai.fun
+    description: >-
+      A shared MCP server providing 30+ utility tools for AI agents: unit
+      conversion, text processing, data parsing, formatting, math, and more.
+      No authentication required.
+    labels:
+      - cloud
+      - python
+    category: developer-tools
   - name: ChronulusAI/chronulus-mcp
     github_id: ChronulusAI/chronulus-mcp
     description:


### PR DESCRIPTION
## Add useful-ai/useful-ai-mcp

Adding [useful-ai/useful-ai-mcp](https://github.com/useful-ai/useful-ai-mcp) to the **Developer Tools** category.

- **GitHub:** https://github.com/useful-ai/useful-ai-mcp
- **Homepage:** https://api.usefulai.fun
- **Category:** developer-tools

### About

A shared MCP server providing 30+ utility tools for AI agents: unit conversion, text processing, data parsing, formatting, math, and more. No authentication required. Listed on Smithery.

### Checklist
- [x] Added to `projects.yaml`
- [x] GitHub repo exists and is public
- [x] Homepage is live