### PR TITLE
Add safari-mcp to browser automation category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -505,6 +505,15 @@ projects:
       - local
       - typescript
     category: browser-automation
+  - name: achiya-automation/safari-mcp
+    github_id: achiya-automation/safari-mcp
+    description: >-
+      Native Safari browser automation for AI agents via AppleScript — 80 tools,
+      zero overhead, keeps logins, runs silently in background. macOS only.
+    labels:
+      - local
+      - typescript
+    category: browser-automation
   - name: Automata-Labs-team/MCP-Server-Playwright
     github_id: Automata-Labs-team/MCP-Server-Playwright
     description: An MCP server for browser automation using Playwright


### PR DESCRIPTION
## Add safari-mcp

**Repository:** https://github.com/achiya-automation/safari-mcp  
**npm:** [safari-mcp](https://www.npmjs.com/package/safari-mcp)  
**Category:** Browser Automation

Native Safari browser automation MCP server for macOS. Uses AppleScript + Swift daemon (no Chromium dependency) to provide 80+ browser automation tools for AI agents.

- 80+ tools (navigate, click, fill, screenshot, cookies, network, performance, a11y)
- ~5ms latency via native macOS APIs
- Zero CPU/RAM overhead (no headless browser)
- Listed on MCP Registry, Smithery, Glama (AAA), awesome-mcp-servers (punkpeye), Cursor Directory