### PR TITLE
Add CompanyScope MCP server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -3586,6 +3586,18 @@ projects:
       - cloud
       - typescript
     category: search-data-extraction
+  - name: Stewyboy1990/companyscope-mcp
+    github_id: Stewyboy1990/companyscope-mcp
+    npm_id: companyscope-mcp
+    description: >-
+      Company intelligence MCP server aggregating 12 free public sources
+      (Wikipedia, SEC EDGAR, OpenCorporates, USPTO patents, GitHub, Brave
+      Search, DNS, RDAP, web scraping). Full company profile in one tool call.
+    labels:
+      - cloud
+      - local
+      - typescript
+    category: search-data-extraction
   - name: vectorize-io/vectorize-mcp-server
     github_id: vectorize-io/vectorize-mcp-server
     description: >-


### PR DESCRIPTION
Adds CompanyScope to the `search-data-extraction` category in `projects.yaml`.

**CompanyScope** is a company intelligence MCP server that aggregates 12 free public data sources into a unified company profile:

- Wikipedia, SEC EDGAR, OpenCorporates (140+ countries), USPTO patents, GitHub, Brave Search, DNS, RDAP, web scraping, and more
- 11 tools including `lookup_company`, `search_sec_filings`, `fetch_patents`, `check_domain_info`
- Available as npm package (`companyscope-mcp`) and remote MCP endpoint
- MIT license

Related: #115