### PR TITLE
Add whasapo - WhatsApp MCP server (Go)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1212,6 +1212,16 @@ projects:
       - go
       - python
     category: communication
+  - name: toloco/whasapo
+    github_id: toloco/whasapo
+    description: >-
+      WhatsApp MCP server written in Go. Send and read messages, list chats, and
+      search contacts from any MCP-compatible client. Single binary, no runtime
+      dependencies, local-only session storage.
+    labels:
+      - go
+      - local
+    category: communication
   - name: line/line-bot-mcp-server
     github_id: line/line-bot-mcp-server
     description: MCP Server for Integrating LINE Official Account


### PR DESCRIPTION
Adds [Whasapo](https://github.com/toloco/whasapo) to the Communication category.

- WhatsApp MCP server written in Go
- Send/read messages, list chats, search contacts
- MIT license, single binary, no runtime dependencies
- Labels: `go`, `local`