### PR TITLE
Add MRC Data to data-platforms category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4045,3 +4045,15 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+
+  - name: MRC Data
+    github_id: meacheal-ai/mrc-data
+    description: >-
+      The first and only MCP server providing structured Chinese fashion supply
+      chain intelligence for AI platforms. 3,000+ verified manufacturers, 350+
+      lab-tested fabrics, 170+ industrial clusters with 63+ dimensions per record.
+    labels:
+      - typescript
+      - remote
+    category: data-platforms
+    homepage: https://api.meacheal.ai


### PR DESCRIPTION
## Summary

Add MRC Data (meacheal-ai/mrc-data) to the data-platforms category in projects.yaml.

MRC Data is China's apparel supply chain data infrastructure for AI agents. It provides 10 MCP tools covering 1,040+ verified Chinese suppliers, 351 lab-tested fabrics, and 173 industrial clusters. Every record is enriched with AATCC / ISO / GB lab test data.

- **GitHub:** https://github.com/meacheal-ai/mrc-data
- **MCP Endpoint:** https://api.meacheal.ai/mcp (HTTP transport, Bearer auth)
- **Docs:** https://api.meacheal.ai/docs
- **Labels:** python, cloud
- **Category:** data-platforms