### PR TITLE
Add WhichModel MCP server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1801,6 +1801,17 @@ projects:
       engineers.
     labels: []
     category: developer-tools
+  - name: Which-Model/whichmodel-mcp
+    github_id: Which-Model/whichmodel-mcp
+    homepage: https://whichmodel.dev
+    description: >-
+      A model routing advisor for autonomous agents — get cost-optimised LLM
+      recommendations via MCP. Query for the best model for any task at the
+      best price, with cross-verified data updated every 4 hours.
+    labels:
+      - cloud
+      - typescript
+    category: developer-tools
   - name: aashari/mcp-server-atlassian-bitbucket
     github_id: aashari/mcp-server-atlassian-bitbucket
     description: >-


### PR DESCRIPTION
## What

Adds [WhichModel](https://whichmodel.dev) to the `developer-tools` category.

## About WhichModel

WhichModel is a remote MCP server that helps AI agents choose the right model for every task at the best price. It exposes a `recommend_model` tool that returns cost-optimised LLM recommendations with cross-verified benchmark data, updated every 4 hours.

- **GitHub:** https://github.com/Which-Model/whichmodel-mcp
- **MCP endpoint:** https://whichmodel.dev/mcp
- **npm:** `@which-model/whichmodel-mcp`
- **Listed on:** Smithery, PulseMCP, Official MCP Registry, Cursor Directory, MCP Market
