### PR TITLE
Add project: Xquik X (Twitter) MCP Server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -3566,6 +3566,17 @@ projects:
       - local
       - typescript
     category: social-media
+  - name: Xquik-dev/x-twitter-scraper
+    github_id: Xquik-dev/x-twitter-scraper
+    description: >-
+      Real-time X (Twitter) data platform for AI agents. 122 REST API endpoints
+      via 2 MCP tools — tweet search, user lookup, bulk extraction (23 tools),
+      write actions, giveaway draws, account monitoring, HMAC webhooks, and
+      trending topics. StreamableHTTP transport with API key auth.
+    labels:
+      - cloud
+      - typescript
+    category: social-media
   - name: r-huijts/strava-mcp
     github_id: r-huijts/strava-mcp
     description: >-


### PR DESCRIPTION
## Add a project

Adds [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) to the **Social Media** category.

Xquik is a real-time X (Twitter) data platform with 2 MCP tools covering 122 REST API endpoints - tweet search, user lookup, bulk extraction (23 tools), write actions, giveaway draws, account monitoring, HMAC webhooks, and trending topics. StreamableHTTP transport with API key auth.

- [x] I have read and follow the [Contributing Guidelines](https://github.com/tolkonepiu/best-of-mcp-servers/blob/main/CONTRIBUTING.md)
- [x] Only `projects.yaml` is modified (README is auto-generated)
