### PR TITLE
Add project: unitedideas/nothumansearch

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4045,3 +4045,13 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+  - name: unitedideas/nothumansearch
+    github_id: unitedideas/nothumansearch
+    description: >-
+      Search engine for AI agents. Discover verified agent-first websites and
+      APIs ranked by agentic readiness (llms.txt, OpenAPI, ai-plugin, MCP,
+      structured API). Public hosted MCP endpoint, no API key required.
+    labels:
+      - cloud
+      - go
+    category: search-data-extraction


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) under Search & Data Extraction.

**Repo:** https://github.com/unitedideas/nothumansearch
**MCP manifest:** https://nothumansearch.ai/.well-known/mcp.json
**Tools:** search, get_site, submit_site, stats
**Access:** Public hosted endpoint, no API key required

Indexes verified agent-first websites and APIs ranked by agentic readiness (llms.txt, OpenAPI, ai-plugin, MCP, structured API).