### PR TITLE
Add project: qartez-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4045,3 +4045,15 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+  - name: kuberstar/qartez-mcp
+    github_id: kuberstar/qartez-mcp
+    description: >-
+      Semantic code intelligence MCP server with 27 tools for project maps,
+      symbol search, impact analysis, call hierarchies, architecture boundaries,
+      dead code detection, and safe refactoring. Pre-computed AST index for fast,
+      token-efficient code exploration.
+    homepage: https://qartez.dev
+    labels:
+      - local
+      - rust
+    category: coding-agents


### PR DESCRIPTION
## Add Qartez MCP Server

**GitHub:** https://github.com/kuberstar/qartez-mcp
**Website:** https://qartez.dev
**Category:** Coding Agents

Qartez is a semantic code intelligence MCP server built in Rust. It provides 27 tools organized in tiers for code navigation, architecture analysis, impact assessment, and safe refactoring. Uses a pre-computed AST-based index for fast, token-efficient code exploration.

Supports Rust, TypeScript, Python, Go, Java, and more.