### PR TITLE
Add project: DollhouseMCP/mcp-server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2739,6 +2739,24 @@ projects:
       - local
       - typescript
     category: knowledge-and-memory
+  - name: DollhouseMCP/mcp-server
+    github_id: DollhouseMCP/mcp-server
+    npm_id: "@dollhousemcp/mcp-server"
+    description: >-
+      One-line installable MCP server that adds reusable customization
+      elements — personas, skills, templates, agents, memory, and
+      ensembles (collected customization tools) — to any MCP Client
+      application. Dynamic permissioning for safe AI operations, a
+      robust validation architecture, versioning, and a public
+      collection of shareable content.
+    labels:
+      - typescript
+      - local
+      - npm
+      - macos
+      - windows
+      - linux
+    category: knowledge-and-memory
   - name: entanglr/zettelkasten-mcp
     github_id: entanglr/zettelkasten-mcp
     description: >-


### PR DESCRIPTION
Adding **DollhouseMCP/mcp-server** to the `knowledge-and-memory` category.

**What it is:** One-line installable MCP server that adds reusable customization elements — personas, skills, templates, agents, memory, and ensembles — to any MCP Client application. Dynamic permissioning for safe AI operations, a robust validation architecture, versioning, and a public collection of shareable content.

**Install:** `npx @dollhousemcp/mcp-server@latest --web`

- Repo: https://github.com/DollhouseMCP/mcp-server
- npm: https://www.npmjs.com/package/@dollhousemcp/mcp-server
- License: AGPL-3.0
- TypeScript, runs locally, supports macOS / Windows / Linux
- Works with Claude Code, Claude Desktop, Cursor, VS Code, Codex, Windsurf, Cline, Gemini CLI, LM Studio, and any MCP client

Added to `projects.yaml` only; no other files edited. YAML parses cleanly.