### PR TITLE
Add Human Pages MCP server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -4051,3 +4051,14 @@ projects:
       - typescript
       - local
     category: other-tools-and-integrations
+
+  - name: Human Pages
+    github_id: human-pages-ai/humanpages
+    npm_id: humanpages
+    description: >-
+      Hire real humans for tasks AI agents cannot do alone. Search by skill,
+      location, language. USDC payments on Base, x402 pay-per-use, Superfluid
+      streaming, on-chain escrow. 36 tools for the full hiring lifecycle.
+    labels:
+      - typescript
+    category: finance-and-fintech


### PR DESCRIPTION
Adds Human Pages to the finance-and-fintech category.

Human Pages is an MCP server that lets AI agents hire real humans for tasks they can't do alone. USDC payments on Base, x402 pay-per-use, Superfluid streaming payments, on-chain escrow with arbitration. 36 tools covering search, jobs, listings, messaging, and payments.

- npm: `humanpages`
- GitHub: `human-pages-ai/humanpages`
- License: MIT