### PR TITLE
Add EnigmAgent MCP server (security category)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -87,6 +87,13 @@ categories:
   - category: security
     title: Security
     subtitle: MCP servers for security analysis and vulnerability scanning
+  - name: EnigmAgent
+    github_id: Agnuxo1/EnigmAgent
+    npm_id: enigmagent-mcp
+    category: security
+    labels: []
+    description: AES-256-GCM + Argon2id encrypted local vault MCP server. Resolves {{PLACEHOLDER}} secrets at runtime so API keys never appear in prompts or logs.
+
   - category: social-media
     title: Social Media
     subtitle: >-


### PR DESCRIPTION
Adds EnigmAgent to the security category in projects.yaml.

**EnigmAgent** — AES-256-GCM + Argon2id encrypted local vault MCP server for AI agent credentials. Resolves `{{PLACEHOLDER}}` secrets at runtime so API keys never appear in prompts, logs, or LLM context.

- npm: `enigmagent-mcp`
- GitHub: https://github.com/Agnuxo1/EnigmAgent
- License: MIT