### PR TITLE
Add KubeStellar Console to Cloud Platforms

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -406,6 +406,13 @@ projects:
       Typescript implementation of Kubernetes cluster operations for pods,
       deployments, services.
     category: cloud-platforms
+  - name: kubestellar/console
+    github_id: kubestellar/console
+    description: >-
+      Multi-cluster Kubernetes dashboard with built-in MCP server (kc-agent) for
+      AI-assisted operations, real-time observability, and integrations with 20+
+      CNCF projects across edge and cloud clusters.
+    category: cloud-platforms
   - name: nwiizo/tfmcp
     github_id: nwiizo/tfmcp
     description: >-


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the Cloud Platforms category in projects.yaml.

KubeStellar Console is a CNCF Sandbox project — a multi-cluster Kubernetes dashboard with a built-in Go MCP server (`kc-agent`) that bridges AI assistants to Kubernetes clusters. It provides tools for managing pods, deployments, services, and 20+ CNCF project resources across edge and cloud clusters.

Entry placed alphabetically after Flux159/mcp-server-kubernetes.