### PR TITLE
Add mcp-apple-notes to knowledge-and-memory

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1744,6 +1744,13 @@ projects:
       Enhanced graph-based memory with a focus on AI role-play and story
       generation
     category: knowledge-and-memory
+  - name: Dan8Oren/mcp-apple-notes
+    github_id: Dan8Oren/mcp-apple-notes
+    description: >-
+      Semantic search and RAG over Apple Notes with on-device embeddings, full
+      CRUD, folder management, and fuzzy title matching. 13 tools. Runs fully
+      locally on macOS — no API keys required. 10 tools.
+    category: knowledge-and-memory
   - name: entanglr/zettelkasten-mcp
     github_id: entanglr/zettelkasten-mcp
     description: >-


### PR DESCRIPTION
**What kind of change does this PR introduce?**
- [x] Add a project

**Description:**
Adds [mcp-apple-notes](https://github.com/Dan8Oren/mcp-apple-notes) to the knowledge-and-memory category in projects.yaml.

A Model Context Protocol server for Apple Notes with semantic search (on-device embeddings via all-MiniLM-L6-v2), full-text search, complete CRUD operations, folder management, and fuzzy title matching. 10 tools. Runs fully locally on macOS — no API keys required.

Also available on npm: `npx -y @dan8oren/mcp-apple-notes`

Entry placed alphabetically after `CheMiguel23/MemoryMesh`.

**Checklist:**
- [x] I have read the CONTRIBUTING guidelines.
- [x] I have not modified the README.md file.