### PR TITLE
Add project: Parsegl/parse-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1879,6 +1879,14 @@ projects:
       A suite of marketing tools from Open Strategy Partners including writing
       style, editing codes, and product marketing value map creation.
     category: marketing
+  - name: Parsegl/parse-mcp
+    github_id: Parsegl/parse-mcp
+    description: >-
+      Look up how any brand surfaces in ChatGPT and Google AI Overviews.
+      Parse's public AI visibility index, queryable from any MCP-capable
+      client. Search brands, prompts, sources, and niches; fetch brand briefs
+      and prompt details; pull dataset stats. 577,000+ brands. No auth required.
+    category: marketing
   - name: pipeboard-co/meta-ads-mcp
     github_id: pipeboard-co/meta-ads-mcp
     description: >-


### PR DESCRIPTION
Adding Parse to the `marketing` category in `projects.yaml`.

Parse is a hosted MCP server that exposes AI brand-visibility data: search how any brand surfaces in ChatGPT and Google AI Overviews, plus the prompts, sources, and niches that drive those answers. 577,000+ brands tracked, read-only, no auth required, HTTP transport at `https://mcp.parse.gl/mcp`.

Repo: https://github.com/Parsegl/parse-mcp

Per CONTRIBUTING.md: added to `projects.yaml` (not the README), individual PR for this project, title format `Add project: project-name`. Inserted alphabetically in the marketing block between `open-strategy-partners` and `pipeboard-co`.