### PR TITLE
Add Inferventis to finance-and-fintech — live financial data MCP

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1595,7 +1595,7 @@ projects:
     category: finance-and-fintech
   - name: Bankee-ai/inferventis
     github_id: Bankee-ai/inferventis
-    homepage: https://mcp-server-295985738387.europe-west1.run.app
+    homepage: https://mcp-server-295985738387.europe-west1.run.app/mcp-pay?src=bestof
     description: >-
       Live financial data MCP for AI agents: real-time FX rates, stock quotes,
       crypto prices (10,000+ coins), Open Banking (PSD2/TrueLayer), Stripe

--- a/projects.yaml
+++ b/projects.yaml
@@ -1593,6 +1593,15 @@ projects:
     description:
       Alpha Vantage API integration to fetch both stock and crypto information
     category: finance-and-fintech
+  - name: Bankee-ai/inferventis
+    github_id: Bankee-ai/inferventis
+    homepage: https://mcp-server-295985738387.europe-west1.run.app
+    description: >-
+      Live financial data MCP for AI agents: real-time FX rates, stock quotes,
+      crypto prices (10,000+ coins), Open Banking (PSD2/TrueLayer), Stripe
+      payment data, financial calculator. Semantic tool_finder discovery.
+      Pay-per-call via x402 micropayments on Base ($0.001 USDC).
+    category: finance-and-fintech
   - name: doggybee/mcp-server-ccxt
     github_id: doggybee/mcp-server-ccxt
     description: >-


### PR DESCRIPTION
**GitHub:** Bankee-ai/inferventis  
**Homepage:** https://mcp-server-295985738387.europe-west1.run.app  
**Category:** finance-and-fintech

Live financial data MCP for AI agents: FX rates, stock quotes, crypto prices (10,000+ coins), Open Banking (PSD2/TrueLayer, 300+ banks), Stripe payment data, financial calculator. Semantic tool_finder discovery engine. Pay-per-call via x402 micropayments on Base ($0.001 USDC) — no account needed.

Also listed on Official MCP Registry as `io.github.jonathanpchapman/inferventis`.