### PR TITLE
Add project: AlexlaGuardia/Vigil

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1916,6 +1916,15 @@ projects:
       Zabbix integration for hosts, items, triggers, templates, problems, data
       and more.
     category: monitoring
+  - name: AlexlaGuardia/Vigil
+    github_id: AlexlaGuardia/Vigil
+    pypi_id: vigil-agent
+    description: >-
+      MCPWatch instruments any Python MCP server in one line. Supports both
+      FastMCP and the low-level mcp.Server. Tracks per-tool latency
+      (p50/p95/p99), error rates, silent failures, and call volume. REST
+      API, CLI, and alert hooks included.
+    category: monitoring
   - name: pydantic/logfire-mcp
     github_id: pydantic/logfire-mcp
     description:


### PR DESCRIPTION
Adds **AlexlaGuardia/Vigil** to the `monitoring` category in `projects.yaml`.

MCPWatch (part of Vigil) instruments any Python MCP server in one line. Supports both `FastMCP` and the low-level `mcp.server.lowlevel.Server`. Tracks:

- Per-tool latency (p50/p95/p99)
- Error rates per tool
- Silent failures (empty/null returns + `isError` responses)
- Call volume over time

Used in production across 95+ MCP tools. MIT, no config required. REST API + CLI + alert hooks.

- Repo: https://github.com/AlexlaGuardia/Vigil
- PyPI: https://pypi.org/project/vigil-agent/
- Article: https://dev.to/alexlaguardia/your-mcp-servers-are-flying-blind-heres-how-to-fix-it-3g51