### PR TITLE
Add project: unitedideas/agentprobe

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2195,6 +2195,18 @@ projects:
       - local
       - macos
     category: developer-tools
+  - name: unitedideas/agentprobe
+    github_id: unitedideas/agentprobe
+    description: >-
+      Probe any seller URL for agentic commerce readiness. Returns a 0-95 score
+      and grade (NOT_READY/PARTIAL/AGENT_READY/CERTIFIED) across 10 checks:
+      llms.txt, OpenAPI, ai-plugin.json, MCP endpoint, commerce.json,
+      catalog/quote/checkout APIs, payment rail declarations, and
+      refund/contact metadata. One MCP tool: probe_site(url).
+    labels:
+      - cloud
+      - go
+    category: developer-tools
   - name: utensils/mcp-nixos
     github_id: utensils/mcp-nixos
     description: >-


### PR DESCRIPTION
Adds agentprobe to the developer-tools category. It probes seller URLs for agentic commerce readiness — 10 checks, 0-95 score, grades NOT_READY/PARTIAL/AGENT_READY/CERTIFIED. MCP tool: probe_site(url). Go + hosted on Fly.io.