### PR TITLE
Add RipperMercs/tensorfeed-mcp under data-platforms

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1072,6 +1072,16 @@ projects:
       interact with Keboola Connection Data Platform. This server provides tools
       for listing and accessing data from Keboola Storage API.
     category: data-platforms
+  - name: RipperMercs/tensorfeed-mcp
+    github_id: RipperMercs/tensorfeed-mcp
+    npm_id: "@tensorfeed/mcp-server"
+    description: >-
+      Real-time AI ecosystem data: AI news from 50+ sources, model pricing,
+      AI service status (Claude, OpenAI, Gemini, etc), MCP registry growth,
+      GitHub trending, AI papers. 8 free tools plus 14 premium x402
+      pay-per-call tools (routing, history series, news search, cost
+      projection, recession watch) in USDC on Base. AFTA-certified.
+    category: data-platforms
   - name: 21st-dev/magic-mcp
     github_id: 21st-dev/magic-mcp
     description:


### PR DESCRIPTION
## What

Adds [RipperMercs/tensorfeed-mcp](https://github.com/RipperMercs/tensorfeed-mcp) (npm: `@tensorfeed/mcp-server`) to `projects.yaml` under the `data-platforms` category, alongside dbt and keboola.

## TensorFeed MCP

Real-time AI ecosystem data MCP server. 42 tools, all read-only and idempotent with annotations.

**Free (no token):** AI news (50+ sources), model pricing across major labs, AI service status (Claude, OpenAI, Gemini, Grok, etc), is-service-down checks, MCP registry growth, GitHub trending, npm/PyPI AI package trending, arXiv + Semantic Scholar + HF Daily papers, agent traffic on tensorfeed.ai itself, model deprecations.

**Premium (USDC on Base via x402, 1-3 credits ~$0.02-0.06 each):** routing recommendations, multi-day pricing/benchmark/status/uptime time series, leaderboard rankings, agents directory, what's-new digest, model comparison, provider deep-dives, news search, cost projection, recession watch, MCP registry growth series, webhook watches.

## Listings

- Official MCP Registry: `ai.tensorfeed/mcp-server`
- npm: [`@tensorfeed/mcp-server`](https://www.npmjs.com/package/@tensorfeed/mcp-server)
- Repo (public): https://github.com/RipperMercs/tensorfeed-mcp
- Site: https://tensorfeed.ai

## AFTA

[Agent Fair-Trade Agreement](https://tensorfeed.ai/agent-fair-trade) certified: code-enforced no-charge guarantees on 5xx, breaker, schema validation failure, or stale data. Every paid call returns an Ed25519-signed receipt verifiable at `/api/receipt/verify`.