### PR TITLE
Add ejentum/ejentum-mcp under coding-agents

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -622,12 +622,7 @@ projects:
     category: coding-agents
   - name: ejentum/ejentum-mcp
     github_id: ejentum/ejentum-mcp
-    description: >-
-      Reasoning Harness for agentic AI: 4 cognitive operating modes (reasoning,
-      code, anti-deception, memory) spanning 679 engineered abilities, served
-      as MCP tools. Each call returns a structured scaffold the LLM absorbs
-      before its first token, catching sycophancy, hallucination, causal
-      shortcuts, and reasoning decay at the moment they would otherwise emerge.
+    description: MCP server with reasoning, code, anti-deception, and memory tools for AI agents.
     category: coding-agents
   - name: aymericzip/intlayer
     github_id: aymericzip/intlayer

--- a/projects.yaml
+++ b/projects.yaml
@@ -620,6 +620,15 @@ projects:
       workflow recording, structured data extraction, and browser DOM
       inspection.
     category: coding-agents
+  - name: ejentum/ejentum-mcp
+    github_id: ejentum/ejentum-mcp
+    description: >-
+      Reasoning Harness for agentic AI: 4 cognitive operating modes (reasoning,
+      code, anti-deception, memory) spanning 679 engineered abilities, served
+      as MCP tools. Each call returns a structured scaffold the LLM absorbs
+      before its first token, catching sycophancy, hallucination, causal
+      shortcuts, and reasoning decay at the moment they would otherwise emerge.
+    category: coding-agents
   - name: aymericzip/intlayer
     github_id: aymericzip/intlayer
     description: >-

--- a/projects.yaml
+++ b/projects.yaml
@@ -622,7 +622,10 @@ projects:
     category: coding-agents
   - name: ejentum/ejentum-mcp
     github_id: ejentum/ejentum-mcp
-    description: MCP server with reasoning, code, anti-deception, and memory tools for AI agents.
+    description: >-
+      MCP server with reasoning, code, anti-deception, and memory tools for AI
+      agents. Two install paths: stdio via `npx -y ejentum-mcp`, or hosted
+      HTTPS at api.ejentum.com/mcp (Bearer auth via EJENTUM_API_KEY).
     category: coding-agents
   - name: aymericzip/intlayer
     github_id: aymericzip/intlayer


### PR DESCRIPTION
Adds `ejentum/ejentum-mcp` to `projects.yaml` under `coding-agents` category.

MCP server (npm `ejentum-mcp` for stdio, or remote HTTPS at `https://api.ejentum.com/mcp`, MIT) exposing four tools: `harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`. Each tool returns a structured prompt that the calling agent ingests before generating.

## Compliance

- Repo public, MIT, actively maintained
- One yaml entry added, category set, github_id matches
- Not a duplicate

Maintainer is me; happy to address review feedback.