### PR TITLE
Add project: tanayshah11/travel-mcp-server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2327,6 +2327,14 @@ projects:
     github_id: openbnb-org/mcp-server-airbnb
     description: Provides tools to search Airbnb and get listing details.
     category: travel-and-transportation
+  - name: tanayshah11/travel-mcp-server
+    github_id: tanayshah11/travel-mcp-server
+    description: >-
+      AI-powered travel search exposing flights, hotels, and weather as MCP
+      tools, with a MongoDB-backed per-tool TTL cache whose timeouts are tuned
+      to each upstream API's reliability characteristics.
+    homepage: https://tanayshah.dev/projects/travel-mcp-server/
+    category: travel-and-transportation
   - name: github/github-mcp-server
     github_id: github/github-mcp-server
     description: >-


### PR DESCRIPTION
Adds [tanayshah11/travel-mcp-server](https://github.com/tanayshah11/travel-mcp-server) under the **Travel & Transportation** category.

The server exposes flights, hotels, and weather as MCP tools, with a MongoDB-backed per-tool TTL cache whose timeouts are tuned to each upstream API's reliability characteristics (longer for slow-changing weather, shorter for live flight pricing).

Architecture write-up + design rationale: https://tanayshah.dev/projects/travel-mcp-server/