### PR TITLE
Add project: NotFair

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1892,6 +1892,16 @@ projects:
       This server supports remote MCP connections, includes built-in Google
       OAuth, and provide an interface to the Google Tag Manager API.
     category: marketing
+  - name: nowork-studio/notfair
+    github_id: nowork-studio/toprank
+    homepage: https://notfair.co
+    description: >-
+      NotFair Google Ads MCP server. Connects Claude and AI agents to a Google
+      Ads account: diagnose campaign performance (CPA, ROAS, search-term waste,
+      quality scores), recommend optimizations (bids, budgets, negatives, ad
+      copy), and execute approved changes via the Google Ads API with a
+      built-in human-approval gate.
+    category: marketing
   - name: grafana/mcp-grafana
     github_id: grafana/mcp-grafana
     description: >-


### PR DESCRIPTION
Adding NotFair under marketing. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Following CONTRIBUTING.md by editing projects.yaml only.