### PR TITLE
Add project: alexisgarcia-dev/claude-mcp-server-template

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1098,6 +1098,15 @@ projects:
       relationships. Generates diagrams and importance scores, helping AI
       assistants understand the codebase.
     category: developer-tools
+  - name: alexisgarcia-dev/claude-mcp-server-template
+    github_id: alexisgarcia-dev/claude-mcp-server-template
+    description: >-
+      Production-survival Python MCP server template. Tools+Resources+Prompts
+      complete, JSON-RPC tools/list healthcheck, OpenTelemetry+Jaeger
+      observability, Streamable HTTP transport, 10 ADR-light decisions
+      documented with verified sources, end-to-end validated quickstart
+      (4 layers). Tag v1.0.0 frozen-by-design.
+    category: developer-tools
   - name: augmnt/augments-mcp-server
     github_id: augmnt/augments-mcp-server
     description: >-


### PR DESCRIPTION
Submitting [alexisgarcia-dev/claude-mcp-server-template](https://github.com/alexisgarcia-dev/claude-mcp-server-template) for inclusion in the **developer-tools** category.

Python MCP server template, v1.0.0 frozen-by-design. Focused on production-survival patterns:
- Tools + Resources + Prompts complete
- JSON-RPC `tools/list` healthcheck
- OpenTelemetry + Jaeger observability
- Streamable HTTP transport with demo Bearer auth + OAuth-ready surface
- 10 ADR-light decisions documented with verified tier-2 sources
- End-to-end validated quickstart (4 layers — final layer is fresh clone from public GitHub URL)

## Repo metadata

- License: MIT
- Language: Python 3.11+
- CI: GitHub Actions matrix Python 3.11 / 3.12 / 3.13 + CodeQL + Bandit weekly + Dependabot
- Tests: 58 passing
- Topics: `mcp`, `model-context-protocol`, `fastmcp`, `python`, `template`, `streamable-http`, `docker`, `opentelemetry`, `jaeger`, `production-template`

## Checklist

- [x] Added to `projects.yaml` (not `README.md`)
- [x] Placed alphabetically by `github_id` within `developer-tools` (between `admica/FileScopeMCP` and `augmnt/augments-mcp-server`)
- [x] YAML validates cleanly (verified with `yaml.safe_load`)
- [x] PR title follows the `Add project: <github_id>` convention from CONTRIBUTING.md
