### PR TITLE
Add dappros/ethora-mcp-server under communication

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -757,10 +757,10 @@ projects:
   - name: dappros/ethora-mcp-cli
     github_id: dappros/ethora-mcp-cli
     description: >-
-      MCP server for the open-source Ethora chat/messaging platform: login,
-      manage apps and chat rooms, broadcast messages, deploy AI bots with RAG
-      sources, and use ERC-20 wallet tools. Supports user-auth and
-      B2B/app-token flows. Run with `npx -y @ethora/mcp-server`.
+      MCP server for the open-source Ethora chat & messaging platform: login,
+      manage apps and chat rooms, broadcast messages, and deploy AI agents /
+      chatbots with RAG sources. Supports user-auth and B2B/app-token flows.
+      Run with `npx -y @ethora/mcp-server`.
     category: communication
   - name: antvis/mcp-server-chart
     github_id: antvis/mcp-server-chart

--- a/projects.yaml
+++ b/projects.yaml
@@ -754,8 +754,8 @@ projects:
       An MCP server for Inbox Zero. Adds functionality on top of Gmail like
       finding out which emails you need to reply to or need to follow up on.
     category: communication
-  - name: dappros/ethora-mcp-cli
-    github_id: dappros/ethora-mcp-cli
+  - name: dappros/ethora-mcp-server
+    github_id: dappros/ethora-mcp-server
     description: >-
       MCP server for the open-source Ethora chat & messaging platform: login,
       manage apps and chat rooms, broadcast messages, and deploy AI agents /

--- a/projects.yaml
+++ b/projects.yaml
@@ -754,6 +754,14 @@ projects:
       An MCP server for Inbox Zero. Adds functionality on top of Gmail like
       finding out which emails you need to reply to or need to follow up on.
     category: communication
+  - name: dappros/ethora-mcp-cli
+    github_id: dappros/ethora-mcp-cli
+    description: >-
+      MCP server for the open-source Ethora chat/messaging platform: login,
+      manage apps and chat rooms, broadcast messages, deploy AI bots with RAG
+      sources, and use ERC-20 wallet tools. Supports user-auth and
+      B2B/app-token flows. Run with `npx -y @ethora/mcp-server`.
+    category: communication
   - name: antvis/mcp-server-chart
     github_id: antvis/mcp-server-chart
     description:


### PR DESCRIPTION
Adds the [Ethora MCP CLI](https://github.com/dappros/ethora-mcp-cli) to the `communication` category in `projects.yaml`.

[Ethora](https://ethora.com) is an open-source chat/messaging platform. Its MCP server (`@ethora/mcp-server`) lets MCP clients log in, manage apps and chat rooms, broadcast messages, deploy AI bots with RAG sources, and use ERC-20 wallet tools across user-auth and B2B/app-token flows.

### Install

```bash
npx -y @ethora/mcp-server
```

Works with Cursor, VS Code MCP, Claude Desktop, Windsurf/Cline. MIT-licensed. npm: https://www.npmjs.com/package/@ethora/mcp-server.
