### PR TITLE
Add project: DocJacket

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2345,6 +2345,15 @@ projects:
       Azure DevOps integration for repository management, work items, and
       pipelines.
     category: version-control
+  - name: DocJacket-LLC/claude-plugin
+    github_id: DocJacket-LLC/claude-plugin
+    homepage: https://docjacket.com/ai-access
+    description: >-
+      Real-estate transaction coordination MCP server. Read transactions, key
+      dates, contingencies, missing documents, and contacts from any MCP client.
+      Hosted at https://mcp.docjacket.com/mcp with OAuth 2.1 + DCR (paste-URL-
+      and-go from Claude, ChatGPT, Codex, or Gemini).
+    category: workplace-and-productivity
   - name: MarkusPfundstein/mcp-gsuite
     github_id: MarkusPfundstein/mcp-gsuite
     description: Integration with gmail and Google Calendar.


### PR DESCRIPTION
Adds DocJacket to `projects.yaml` under `workplace-and-productivity`.

**What it is:** Real-estate transaction coordination MCP server. Read transactions, key dates, contingencies, missing documents, and contacts from any MCP client (Claude, ChatGPT, Codex, Gemini).

**Hosting:** Hosted SaaS at https://mcp.docjacket.com/mcp (no self-hosting required)

**Auth:** OAuth 2.1 + PKCE + Dynamic Client Registration (RFC 7591) — paste-URL-and-go

**Repo:** https://github.com/DocJacket-LLC/claude-plugin

**Homepage:** https://docjacket.com/ai-access

Slotted alphabetically before `MarkusPfundstein/mcp-gsuite` within the existing workplace-and-productivity category. YAML validated locally.