### PR TITLE
Add project: agentic-security-shield

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2260,6 +2260,20 @@ projects:
       and runs locally via Docker or as a standalone binary for fast, automated
       vetting.
     category: security
+  - name: agentic-security-shield
+    github_id: ormuzdo/agentic-security-shield
+    homepage: https://agentic-security-shield-mcp-production.up.railway.app
+    description: >-
+      Drop-in security configs for AI coding agents. 12 layers of protection
+      across 17 AI tools (Claude Code, Cursor, Copilot, Bolt.new, Lovable,
+      v0.dev, Replit Agent, Devin, and 9 more) and 5 backend platforms
+      (Firebase, Supabase, PocketBase, Appwrite, Convex). Defends against
+      prompt injection, MCP tool poisoning, leaked secrets, SSRF, eval
+      injection, PII exposure, autonomous OAuth approval, and subagent
+      privilege escalation. Remote HTTP MCP server with autonomous A2A
+      purchase via x402 (19 USDC on Base, single-use replay-protected).
+      SHA-256 file integrity manifest.
+    category: security
   - name: HagaiHen/facebook-mcp-server
     github_id: HagaiHen/facebook-mcp-server
     description: >-


### PR DESCRIPTION
## Adding `ormuzdo/agentic-security-shield`

Per CONTRIBUTING.md — adding via `projects.yaml` in the `security` category.

### Project overview

Drop-in security configuration files for AI coding agents. Sold as an MCP server (remote, Streamable HTTP). 12 layers of protection across 17 AI coding tools (Claude Code, Cursor, Copilot, Bolt.new, Lovable, v0.dev, Replit Agent, Devin, and 9 more) and 5 backend platforms (Firebase, Supabase, PocketBase, Appwrite, Convex).

Defends against:
- Prompt injection (incl. zero-width Unicode steganography)
- MCP tool-description poisoning (Invariant Labs, Apr 2025)
- 35+ hardcoded-secret patterns (AWS, OpenAI project keys, Anthropic admin, Stripe, etc.)
- SSRF / eval / PII / RBAC / least-privilege violations
- Computer Use & subagent privilege escalation
- Agent memory poisoning & infinite-loop attacks

### Distribution
- [Smithery listing](https://smithery.ai/server/ormuzdo/agentic-security-shield)
- [Official MCP Registry](https://registry.modelcontextprotocol.io) entry: `io.github.ormuzdo/agentic-security-shield` v1.0.0
- Source manifests: [github.com/ormuzdo/agentic-security-shield](https://github.com/ormuzdo/agentic-security-shield)

### A2A commerce
- x402-v1 compliant (`accepts[]` with `tx-hash` and `exact` schemes)
- `WWW-Authenticate: x402` header on 402 responses
- Single-use, replay-protected on-chain USDC verification on Base
- SHA-256 file integrity manifest delivered with the product

Followed the project property format and inserted in the `security` category.