### PR TITLE
Add project: brewpage-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1563,6 +1563,13 @@ projects:
       MCP tool access to MarkItDown -- a library that converts many file formats
       (local or remote) to Markdown for LLM consumption.
     category: file-systems
+  - name: kochetkov-ma/brewpage-openapi
+    github_id: kochetkov-ma/brewpage-openapi
+    npm_id: brewpage-mcp
+    description: >-
+      MCP server for BrewPage -- free, no-signup hosting for HTML, Markdown,
+      key-value, JSON, files and multi-file sites via a public REST API.
+    category: file-systems
   - name: aaronjmars/web3-research-mcp
     github_id: aaronjmars/web3-research-mcp
     description: Deep Research for crypto - free & fully local


### PR DESCRIPTION
Adds [brewpage-mcp](https://github.com/kochetkov-ma/brewpage-openapi) to the **file-systems** category.

BrewPage (`https://brewpage.app`) is a free, MIT-licensed HTML/Markdown/KV/JSON/file hosting platform — no signup, short URLs, owner-token model for writes. The MCP server lets agents publish content to a public REST API.

- **GitHub**: https://github.com/kochetkov-ma/brewpage-openapi (server in `mcp-server/`)
- **npm**: [`brewpage-mcp`](https://www.npmjs.com/package/brewpage-mcp) (v1.5.1)
- **Official MCP Registry**: `io.github.kochetkov-ma/brewpage-mcp`
- **Tools**: 14 (publish/update/delete HTML/KV/JSON/files/sites + get_page + get_stats + gallery search)
- **Docs / OpenAPI**: https://kochetkov-ma.github.io/brewpage-openapi/

Entry inserted alphabetically within the `file-systems` category (between `microsoft/markitdown` and the next section). Project meets best-of-generator schema (`name`, `github_id`, `npm_id`, `description`, `category`).