### PR TITLE
Add project: ejentum-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2575,3 +2575,13 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: ejentum/ejentum-mcp
+    github_id: ejentum/ejentum-mcp
+    npm_id: ejentum-mcp
+    description: >-
+      Reasoning harness exposing four agentic tools (reasoning, code,
+      anti-deception, memory) the agent calls during its loop. Each call
+      returns a structured cognitive operation (named failure pattern,
+      executable procedure, suppression vectors, falsification test) the
+      model reads internally.
+    category: other-tools-and-integrations


### PR DESCRIPTION
Adds `ejentum/ejentum-mcp` to `projects.yaml` under `other-tools-and-integrations` (no "reasoning" category exists yet; happy to relocate if one is added or if a different existing category fits better).

`ejentum-mcp` is a pre-generation reasoning harness MCP server. Four agent-callable tools (`harness_reasoning`, `harness_code`, `harness_anti_deception`, `harness_memory`) return structured cognitive scaffolds (named failure pattern, executable procedure, suppression vectors, falsification test) the model reads before producing its user-facing answer.

- npm: https://www.npmjs.com/package/ejentum-mcp (v0.1.x, OIDC provenance)
- Source: https://github.com/ejentum/ejentum-mcp
- Hosted: https://api.ejentum.com/mcp
- License: MIT

YAML syntax verified clean with PyYAML.