### PR TITLE
Add mstang/casemgr-mcp to workplace-and-productivity

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2368,6 +2368,14 @@ projects:
       Search, read, create, and update Bear Notes directly from Claude.
       Local-only with complete privacy.
     category: workplace-and-productivity
+  - name: mstang/casemgr-mcp
+    github_id: mstang/casemgr-mcp
+    description: >-
+      Shared workspace your AI agents write to. CMMN case management with 184 MCP tools
+      covering cases, tasks, event-driven CMMN workflows with sentries, persistent memory
+      with semantic search, billing and invoicing. OAuth or token auth; hosted MCP endpoint
+      at casemgr.systems.
+    category: workplace-and-productivity
   - name: AbdelStark/bitcoin-mcp
     github_id: AbdelStark/bitcoin-mcp
     description: >-

--- a/projects.yaml
+++ b/projects.yaml
@@ -2371,10 +2371,10 @@ projects:
   - name: mstang/casemgr-mcp
     github_id: mstang/casemgr-mcp
     description: >-
-      Shared workspace your AI agents write to. CMMN case management with 184 MCP tools
-      covering cases, tasks, event-driven CMMN workflows with sentries, persistent memory
-      with semantic search, billing and invoicing. OAuth or token auth; hosted MCP endpoint
-      at casemgr.systems.
+      Shared workspace your AI agents write to. CMMN case management
+      with 184 MCP tools: cases, tasks, event-driven CMMN workflows,
+      persistent memory with semantic search, billing and invoicing.
+      OAuth or token auth; hosted MCP endpoint at casemgr.systems.
     category: workplace-and-productivity
   - name: AbdelStark/bitcoin-mcp
     github_id: AbdelStark/bitcoin-mcp


### PR DESCRIPTION
Adds [CaseMgr MCP](https://github.com/mstang/casemgr-mcp) under the `workplace-and-productivity` category in `projects.yaml`.

CMMN-based case management server — 184 MCP tools, event-driven workflows, persistent memory with semantic search, billing. OAuth or token auth.