### PR TITLE
Add project: Gapup MCP

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2575,3 +2575,15 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+
+  - name: Gapup MCP
+    github_id: getgapup/gapup-mcp-public
+    description: >-
+      185 agent-payable C-suite expertise tools — SEC filings, 8-list sanctions/KYC,
+      clinical evidence (GRADE-graded), EU AI Act compliance, EU-first real estate,
+      research paper Q&A. Pay-per-call via x402 (USDC/EURC on Base + Optimism).
+      100 free calls/month, no credit card.
+    homepage: https://hub.gapup.io/agents-api
+    license: MIT
+    labels: ["mcp", "x402", "compliance", "finance"]
+    category: finance-and-fintech


### PR DESCRIPTION
Adds Gapup MCP to projects.yaml in the `finance-and-fintech` category.

**Server**: Gapup MCP — hosted MCP server with **185 agent-payable C-suite expertise tools** spanning SEC filings, 8-list sanctions screener (OFAC/EU/UK/UN/SECO/SEMA/DFAT), KYC, clinical evidence (GRADE-graded), EU AI Act compliance, EU-first real estate (DVF Cerema + Géorisques), research paper Q&A (OpenAlex 45M), +50 more verticals.

- **Repo (MIT)** : https://github.com/getgapup/gapup-mcp-public
- **Endpoint** : `https://mcp.gapup.io/mcp`
- **Pricing** : x402 micro-payments (USDC/EURC, Base + Optimism), 100 free calls/month no card, then $0.05–$0.30 per call
- **Already listed** : Smithery (verified), Glama, MCP Registry officiel (`io.github.getgapup/gapup-mcp`), Cursor Directory, MCPBundles, HuggingFace Spaces, abordage/awesome-mcp, JAW9C/awesome-remote-mcp-servers (PR #344)

🤖 Generated with [Claude Code](https://claude.com/claude-code)