### PR TITLE
Add project: just-an-oldsalt/proto-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2575,3 +2575,12 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: just-an-oldsalt/proto-mcp
+    github_id: just-an-oldsalt/proto-mcp
+    description: >-
+      Local-only macOS daemon that bridges Proton Mail to Claude Desktop
+      and Claude Code via Touch-ID-gated MCP tool calls. 29 tools across
+      read, search, compose, label, and send paths with a per-tool YAML
+      policy engine and a redacted audit log. Developer-ID signed +
+      Apple-notarized; installs via `brew install --cask proto-mcp`.
+    category: communication


### PR DESCRIPTION
Adds [proto-mcp](https://github.com/just-an-oldsalt/proto-mcp) to the `communication` category.

**What it is:** Local-only macOS daemon that bridges Proton Mail to Claude Desktop / Claude Code via Touch-ID-gated MCP tool calls. 29 tools across read / search / compose / label / send paths with a per-tool YAML policy engine and a redacted audit log.

**Quality markers:**
- v1.0.1 released; Developer-ID signed + Apple-notarized
- Distributed via Homebrew cask: `brew install --cask proto-mcp`
- Per-tool policy engine + audit log (every tool call gated, every write Touch-ID-prompted)
- 37 documented security-defect closures, 5 remaining tracked publicly in DEFECTS.html
- GPLv3, trust model documented in SECURITY.md

Appended to the bottom of projects.yaml per CONTRIBUTING.md. Followed the per-project commit title format (`Add project: ...`).