### PR TITLE
Add CarVector MCP server (vehicle specs, federal recalls, OBD-II DTC reference)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2327,6 +2327,10 @@ projects:
     github_id: openbnb-org/mcp-server-airbnb
     description: Provides tools to search Airbnb and get listing details.
     category: travel-and-transportation
+  - name: carvectorio/carvector-mcp
+    github_id: carvectorio/carvector-mcp
+    description: Vehicle specs, federal recall data, and OBD-II DTC
+    category: travel-and-transportation
   - name: github/github-mcp-server
     github_id: github/github-mcp-server
     description: >-


### PR DESCRIPTION
Adds [carvectorio/carvector-mcp](https://github.com/carvectorio/carvector-mcp) under **Travel & Transportation**

- npm: https://www.npmjs.com/package/carvector-mcp (MIT)
- Official MCP registry: `io.github.carvectorio/carvector-mcp` v1.0.1 active — https://registry.modelcontextprotocol.io/v0/servers?search=carvector
- Site & docs: https://carvector.io

Bundled API: vehicle specs (12,000+ vehicles 1925–2029), federal recall campaigns, and OBD-II DTC reference. Open-source MCP client installs with `npx -y carvector-mcp`. Free tier, no credit card.

Alphabetical placement: between `campertunity/mcp-server` and `cobanov/teslamate-mcp`. One server per line, format matches neighbors.