### PR TITLE
Add projects: Clawdio777/aeonos-mcp and Clawdio777/verity

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1988,6 +1988,16 @@ projects:
       multi-language support, and comprehensive search capabilities including
       headlines, stories, and related topics through SerpAPI.
     category: search-data-extraction
+  - name: Clawdio777/verity
+    github_id: Clawdio777/verity
+    npm_id: verity-mcp
+    description: >-
+      Real-time fact-checking MCP server that verifies claims, URLs, and content
+      against live web sources. Returns structured verdicts (CURRENT, OUTDATED,
+      DISPUTED, or UNVERIFIABLE) with confidence scores and exactly what changed.
+      Eliminates AI hallucinations and stale data in content pipelines. No API
+      key required — pay-per-call via x402 on Base.
+    category: search-data-extraction
   - name: ConechoAI/openai-websearch-mcp
     github_id: ConechoAI/openai-websearch-mcp
     description:

--- a/projects.yaml
+++ b/projects.yaml
@@ -1988,6 +1988,16 @@ projects:
       multi-language support, and comprehensive search capabilities including
       headlines, stories, and related topics through SerpAPI.
     category: search-data-extraction
+  - name: Clawdio777/aeonos-mcp
+    github_id: Clawdio777/aeonos
+    npm_id: aeonos-mcp
+    description: >-
+      AI Search Visibility Agent — audits websites for AEO/GEO readiness and
+      optimises for citation by ChatGPT, Perplexity, Claude, and Google AI
+      Overviews. Returns P1/P2/P3 gap analysis, JSON-LD schema generation, E-E-A-T
+      scoring, entity disambiguation, and llms.txt generation. Pay-per-call via
+      x402 on Base. No API key required.
+    category: search-data-extraction
   - name: Clawdio777/verity
     github_id: Clawdio777/verity
     npm_id: verity-mcp


### PR DESCRIPTION
Adding two BaseChain Labs agents to the search-data-extraction category:

**AEONOS** (`Clawdio777/aeonos` / npm: `aeonos-mcp`) — AI Search Visibility Agent that audits websites for AEO/GEO readiness, returns P1/P2/P3 gap analysis, JSON-LD schema, E-E-A-T scoring, and llms.txt generation. Pay-per-call via x402 on Base.

**VERITY** (`Clawdio777/verity` / npm: `verity-mcp`) — Real-time fact-checking MCP server that verifies claims, URLs, and content against live web sources. Returns structured verdicts (CURRENT/OUTDATED/DISPUTED/UNVERIFIABLE) with confidence scores. No API key required, pay-per-call via x402.