### PR TITLE
Add ProposalCraft to workplace-and-productivity

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2368,6 +2368,13 @@ projects:
       Search, read, create, and update Bear Notes directly from Claude.
       Local-only with complete privacy.
     category: workplace-and-productivity
+  - name: bradshawprojects/proposalcraft
+    github_id: bradshawprojects/proposalcraft
+    description: >-
+      MCP server for freelancers and consultants that drafts client proposals in
+      your voice. Save past winning proposals, paste a new brief, and get a
+      ready-to-send proposal in seconds. Local-first, no API key required.
+    category: workplace-and-productivity
   - name: AbdelStark/bitcoin-mcp
     github_id: AbdelStark/bitcoin-mcp
     description: >-


### PR DESCRIPTION
## ProposalCraft

**ProposalCraft** is a free, open-source MCP server that drafts client proposals in your own voice, learned from your past winning work.

**Category:** `workplace-and-productivity` — automates one of the most time-intensive freelance workflows (brief → polished proposal)

### What it does
- Save 2-3 past winning proposals as style guides
- Paste any new client brief
- Get a ready-to-send proposal in seconds — in your voice

### Why it fits here
Freelancers and consultants spend 2-4h per proposal and typically win ~25% of pitches. ProposalCraft reduces that to 30 seconds. It's local-first, no API key, no cloud storage.

### Details
- **GitHub:** https://github.com/bradshawprojects/proposalcraft
- **License:** MIT
- **5 tools:** `analyze_brief`, `draft_proposal`, `save_proposal`, `list_proposals`, `delete_proposal`
- **Install:** `npx -y github:bradshawprojects/proposalcraft`