### PR TITLE
Add project: Doxa MCP

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2575,3 +2575,12 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: The-Doxa-Way/doxa-mcp-schema
+    github_id: The-Doxa-Way/doxa-mcp-schema
+    description: >-
+      Free hosted MCP server for Christian encouragement and Bible lookup, with
+      three tools grounded in the Berean Standard Bible (public domain):
+      encouragement, scripture verse lookup with deep links, and Doxa Way
+      movement guidance. Remote streamable HTTP at https://doxa.app/mcp/v1, with
+      optional bring-your-own-licence for unlimited use.
+    category: art-and-culture


### PR DESCRIPTION
Adds Doxa MCP to `projects.yaml` under the `art-and-culture` category (which already exists in the file). The entry follows the same shape as existing entries: `name`, `github_id` (The-Doxa-Way/doxa-mcp-schema), folded `description`, and `category`. No edits to `README.md`, which is auto-generated and rebuilt weekly.

About Doxa MCP:

- A free hosted, remote (streamable HTTP) Model Context Protocol server for Christian encouragement and Bible lookup, usable from Claude Desktop, Cursor, Cline, LibreChat, and any MCP client.
- Endpoint: https://doxa.app/mcp/v1 . Landing page: https://doxa.app/mcp . Schema repo: https://github.com/The-Doxa-Way/doxa-mcp-schema . npm client: @thedoxaway/mcp-client
- Three tools, all grounded in the Berean Standard Bible (public domain): doxa_encourage (Scripture-grounded encouragement), doxa_scripture (BSB verse lookup with deep links), doxa_way_movement (guidance through the Doxa Way).
- The free hosted tier needs no credentials; bring your own licence (one header) unlocks unlimited use.
- It is the only Christian MCP publishing a public 5/5 pass on the independent faith.tools Christian-AI safety rubric, including crisis handling.

Install snippet for any MCP client config:

```json
{"mcpServers":{"doxa":{"command":"npx","args":["-y","mcp-remote","https://doxa.app/mcp/v1"]}}}
```
