### PR TITLE
Add kirvigen/notion-private-api-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2525,6 +2525,13 @@ projects:
     github_id: suekou/mcp-notion-server
     description: Interacting with Notion API
     category: other-tools-and-integrations
+  - name: kirvigen/notion-private-api-mcp
+    github_id: kirvigen/notion-private-api-mcp
+    npm_id: notion-private-mcp
+    description: Unofficial MCP server built on the private Notion API (token_v2),
+      giving AI agents full read/write access to your entire workspace with no
+      integration token and no per-page sharing.
+    category: workplace-and-productivity
   - name: tacticlaunch/mcp-linear
     github_id: tacticlaunch/mcp-linear
     description: Integrates with Linear project management system

--- a/projects.yaml
+++ b/projects.yaml
@@ -2528,9 +2528,10 @@ projects:
   - name: kirvigen/notion-private-api-mcp
     github_id: kirvigen/notion-private-api-mcp
     npm_id: notion-private-mcp
-    description: Unofficial MCP server built on the private Notion API (token_v2),
-      giving AI agents full read/write access to your entire workspace with no
-      integration token and no per-page sharing.
+    description: >-
+      Unofficial MCP server built on the private Notion API (token_v2),
+      giving AI agents full read/write access to your entire workspace
+      with no integration token and no per-page sharing.
     category: workplace-and-productivity
   - name: tacticlaunch/mcp-linear
     github_id: tacticlaunch/mcp-linear


### PR DESCRIPTION
Adds **kirvigen/notion-private-api-mcp** to `projects.yaml` under `workplace-and-productivity`.

An unofficial MCP server built on Notion's private API (`token_v2` cookie) that gives AI agents full read/write access to the entire workspace with no integration token and no per-page sharing.

- npm: `notion-private-mcp`
- stdio transport, official MCP SDK
- MIT licensed, indexed on Glama