### PR TITLE
Add TWZRD Agent Intel to Finance & Fintech category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,8 +1679,8 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
-  - name: twzrd-sol/wzrd-final
-    github_id: twzrd-sol/wzrd-final
+  - name: TWZRD Agent Intel
+    homepage: https://intel.twzrd.xyz
     description: >-
       Solana-native agent trust scoring via x402 micropayments — free on-chain
       preflight checks + paid signed V5 trust receipts settled in <1s. Remote

--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,6 +1679,13 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: twzrd-sol/wzrd-final
+    github_id: twzrd-sol/wzrd-final
+    description: >-
+      Solana-native agent trust scoring via x402 micropayments — free on-chain
+      preflight checks + paid signed V5 trust receipts settled in <1s. Remote
+      MCP at intel.twzrd.xyz/mcp.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
## Summary

- Adds **TWZRD Agent Intel** (TWZRD Agent Intel) to the `finance-and-fintech` category
- Solana-native MCP server for agent trust scoring via x402 micropayments
- Free on-chain preflight checks (no payment required) + paid signed V5 trust receipts settled in <1s via remote endpoint at `intel.twzrd.xyz/mcp`

## Server Details

- **GitHub**: https://intel.twzrd.xyz
- **Remote endpoint**: `intel.twzrd.xyz/mcp`
- **Language**: Python, remote-only
- **Category**: Finance & Fintech (x402 micropayment infrastructure on Solana)

## Test plan

- [ ] Verify entry appears in `finance-and-fintech` section of `projects.yaml`
- [ ] Verify YAML is valid (entry follows existing schema: `name`, `github_id`, `description`, `category`)
- [ ] Confirm no other sections are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)