### PR TITLE
feat: add The Stall to Finance & Fintech — 210 pay-per-call tools (v4.64.0)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,6 +1679,14 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: thebrierfox/the-stall
+    github_id: thebrierfox/the-stall
+    homepage: https://the-stall.intuitek.ai/mcp
+    description: >-
+      172 pay-per-call financial and market intelligence tools via x402 USDC
+      micropayments on Base. Covers equities, crypto/DeFi, macro, on-chain
+      analytics, options, alternative data, and 20+ verticals. No API key.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
## The Stall

Adds `thebrierfox/the-stall` to the Finance & Fintech category.

**GitHub:** https://github.com/thebrierfox/the-stall  
**MCP URL:** https://the-stall.intuitek.ai/mcp

### Description
210 pay-per-call financial and market intelligence tools via x402 USDC micropayments on Base. Covers equities (stock price, fundamentals, earnings, options chain, insider trades), crypto/DeFi (prices, DEX swap quotes, whale radar, protocol revenue, stablecoin watch), macro (FOMC, treasury yields, IMF outlook, economic calendar), on-chain analytics (EVM logs, wallet balance, ENS lookup), and 20+ more verticals. Remote MCP server — no API key required.