### PR TITLE
Add KanseiLink to Aggregators section

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -155,6 +155,13 @@ projects:
       Intelligent search capabilities to let every model and client use Claude
       Agent Skills like native.
     category: aggregators
+  - name: kansei-link/kansei-mcp-server
+    github_id: kansei-link/kansei-mcp-server
+    npm_id: "@kansei-link/mcp-server"
+    description: >-
+      Local-first MCP navigator with verified data on 11,000+ SaaS services,
+      200 workflow recipes, and 89-97% token savings vs web search. MIT licensed.
+    category: aggregators
   - name: metatool-ai/metamcp
     github_id: metatool-ai/metamcp
     description: >-


### PR DESCRIPTION
## New Project: KanseiLink

- **GitHub:** https://github.com/kansei-link/kansei-mcp-server
- **npm:** [@kansei-link/mcp-server](https://www.npmjs.com/package/@kansei-link/mcp-server)
- **Category:** Aggregators
- **License:** MIT

### Description

Local-first MCP navigator with verified data on 11,000+ SaaS services, 200 workflow recipes, and 89-97% token savings vs web search. Runs entirely on local SQLite — no API keys, no cloud dependency.

Works with Claude Code, Cursor, Cline, Zed, Windsurf — any MCP client.