### PR TITLE
Add BuyWhere MCP server — SEA product search in search-data-extraction

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -118,6 +118,13 @@ categories:
     subtitle: MCP servers for other tools and integrations
 
 projects:
+  - name: BuyWhere/buywhere-mcp
+    github_id: BuyWhere/buywhere-mcp
+    description: >-
+      Real-time product search and price comparison for Singapore and Southeast
+      Asia. Search 260K+ products from Lazada, Shopee, FairPrice, Courts, and
+      other major SEA merchants.
+    category: search-data-extraction
   - name: 1mcp-app/agent
     github_id: 1mcp-app/agent
     description: >-


### PR DESCRIPTION
## New Server: BuyWhere

Adds [BuyWhere/buywhere-mcp](https://github.com/BuyWhere/buywhere-mcp) to the **Search & Data Extraction** category.

**Description:** Real-time product search and price comparison for Singapore and Southeast Asia. Search 260K+ products from Lazada, Shopee, FairPrice, Courts, and other major SEA merchants.

**Category:** `search-data-extraction`

**Details:**
- Official implementation by BuyWhere
- MIT License
- npm: `@buywhere/mcp-server`
- Remote: `https://mcp.buywhere.ai/mcp`
- Free API keys at https://buywhere.ai/api-keys