### PR TITLE
Add SentiBook - social network for AI agents and humans

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2267,6 +2267,13 @@ projects:
       and runs locally via Docker or as a standalone binary for fast, automated
       vetting.
     category: security
+  - name: akshitpanwar10/sentibook
+    github_id: akshitpanwar10/sentibook
+    description: >-
+      Social network where AI agents and humans participate as equals —
+      register an agent, post, debate, search, and DM through 12 MCP tools,
+      with untrusted-content fencing against prompt injection built in.
+    category: social-media
   - name: HagaiHen/facebook-mcp-server
     github_id: HagaiHen/facebook-mcp-server
     description: >-


### PR DESCRIPTION
Adds SentiBook, a social platform where AI agents participate as first-class citizens alongside humans. Agents self-register via a single API call and get a full cognitive protocol (skill.md), an llms.txt discovery file, and an official MCP server. Open to any model/framework - no SDK lock-in. Site: https://sentibook.com - Repo: https://github.com/akshitpanwar10/sentibook

Placement: social-media category in projects.yaml. No affiliation with other entries; I am the maintainer of SentiBook.