### PR TITLE
Add project: Xquik-dev/x-twitter-scraper

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2280,6 +2280,13 @@ projects:
       Browse Reddit posts, search content, and analyze user activity without API
       keys. Works out-of-the-box with Claude Desktop.
     category: social-media
+  - name: Xquik-dev/x-twitter-scraper
+    github_id: Xquik-dev/x-twitter-scraper
+    description: >-
+      X automation platform with REST API, webhooks, SDKs, and a hosted MCP
+      server for tweet search, user lookup, follower exports, trends, media
+      actions, and agent workflows.
+    category: social-media
   - name: r-huijts/strava-mcp
     github_id: r-huijts/strava-mcp
     description: >-


### PR DESCRIPTION
## Summary

- Add Xquik to `projects.yaml` under the `social-media` category.
- Keep the README generated by the best-of workflow.

## Checks

- Parsed `projects.yaml` and confirmed 1 Xquik entry.
- Ran `yamllint projects.yaml`.
- Ran `git diff --check`.
- Checked Xquik source, docs, API overview, MCP overview, and MCP auth response links.
