### PR TITLE
Add RugCheck AI — on-chain Solana token safety MCP

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,7 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: MrWizardlyLoaf/rugcheck-ai
+    github_id: MrWizardlyLoaf/rugcheck-ai
+    description: On-chain Solana token safety — screen a token for rug pulls, honeypots and authority traps before trading, then execute MEV-protected swaps.
+    category: security


### PR DESCRIPTION
Adds **RugCheck AI**, an on-chain Solana token-safety MCP server.

- Reads the token mint directly via `getAccountInfo` to flag active mint/freeze authority and dangerous Token-2022 extensions (permanent delegate, transfer hook, non-transferable, pausable) **before** an agent trades.
- Tools: `verify_token_safety`, `check_authorities`, `simulate_sell`, `execute_safe_swap`.
- Listed on the official MCP Registry as `io.github.MrWizardlyLoaf/rugcheck-ai`.
- Repo: https://github.com/MrWizardlyLoaf/rugcheck-ai

Category: `security`