### PR TITLE
Add Armigerous/dependency-freshness-mcp (developer-tools)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1098,6 +1098,12 @@ projects:
       relationships. Generates diagrams and importance scores, helping AI
       assistants understand the codebase.
     category: developer-tools
+  - name: Armigerous/dependency-freshness-mcp
+    github_id: Armigerous/dependency-freshness-mcp
+    description: >-
+      npm & PyPI dependency freshness (version lag + dated breaking-change
+      diffs) for AI coding agents, via MCP.
+    category: developer-tools
   - name: augmnt/augments-mcp-server
     github_id: augmnt/augments-mcp-server
     description: >-


### PR DESCRIPTION
## Summary

Adds `Armigerous/dependency-freshness-mcp` to the **developer-tools** category.

**YAML entry:**
```yaml
- name: Armigerous/dependency-freshness-mcp
  github_id: Armigerous/dependency-freshness-mcp
  description: >-
    npm & PyPI dependency freshness (version lag + dated breaking-change
    diffs) for AI coding agents, via MCP.
  category: developer-tools
```

**What it does:** MCP server that checks npm & PyPI dependency freshness for AI coding agents — latest version, release dates, deprecations, and dated, cited breaking-change diffs. Addresses the training-cutoff blind spot for AI coding tools.

- GitHub: https://github.com/Armigerous/dependency-freshness-mcp
- Apify Actor (remote MCP): https://apify.com/peppy_weekend/dependency-freshness-mcp