### PR TITLE
Add mindcore-memory-mcp to knowledge-and-memory category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1848,6 +1848,14 @@ projects:
       (95.4%).
     pypi_id: omega-memory
     category: knowledge-and-memory
+  - name: woshilaohei/mindcore-memory-mcp
+    github_id: woshilaohei/mindcore-memory-mcp
+    description: >-
+      Production-grade MCP memory server with hybrid BM25+FAISS search, 3-state
+      circuit breaker, 3D boundary balance algorithm, content deduplication, and
+      Prometheus metrics. 9 tools, 132 tests, zero external API dependencies.
+    pypi_id: mindcore-memory
+    category: knowledge-and-memory
   - name: jagan-shanmugam/open-streetmap-mcp
     github_id: jagan-shanmugam/open-streetmap-mcp
     description:


### PR DESCRIPTION
## What

Adds **mindcore-memory-mcp** ([repo](https://github.com/woshilaohei/mindcore-memory-mcp)) to the knowledge-and-memory category.

**MindCore Memory** is a production-grade MCP memory server featuring:

- Hybrid BM25+FAISS search with graceful circuit-breaker fallback
- 3D Boundary Balance Algorithm (self-curating memory quality, <1ms, zero LLM)
- Content deduplication, rate limiting, Prometheus metrics
- 132/132 tests, MIT licensed, zero external API dependencies

PyPI: pip install mindcore-memory`nMCP Registry: published and verified