### PR TITLE
feat: add Disentinel/grafema — code graph MCP server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1143,6 +1143,16 @@ projects:
     github_id: delano/postman-mcp-server
     description: Interact with Postman API
     category: developer-tools
+  - name: Disentinel/grafema
+    github_id: Disentinel/grafema
+    npm_id: grafema
+    description: >-
+      Semantic code graph MCP server for AI coding agents. Indexes codebases
+      into typed graphs (functions/types/modules as nodes; CALLS/IMPORTS/DATAFLOW
+      edges) with 40+ tools for call-chain tracing, data-flow analysis, and
+      semantic code search.
+    category: developer-tools
+    license: FSL-1.1-Apache-2.0
   - name: docker/hub-mcp
     github_id: docker/hub-mcp
     description: >-


### PR DESCRIPTION
## What

Adds [Grafema](https://github.com/Disentinel/grafema) to the `developer-tools` category.

## About Grafema

Grafema is a semantic code graph MCP server for AI coding agents. It indexes a codebase into a typed graph and exposes 40+ MCP tools for AI agents to query code structure, trace call chains, and analyze data flow — instead of reading files line by line.

- **GitHub**: https://github.com/Disentinel/grafema
- **npm**: `npm install -g grafema`
- **Version**: 0.4.1
- **Transport**: stdio
- **License**: FSL-1.1-Apache-2.0
- **Platforms**: macOS (arm64/x64), Linux (arm64/x64)