### PR TITLE
feat: add Disentinel/grafema — semantic code graph MCP server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1143,6 +1143,16 @@ projects:
     github_id: delano/postman-mcp-server
     description: Interact with Postman API
     category: developer-tools
+  - name: Disentinel/grafema
+    github_id: Disentinel/grafema
+    npm_id: grafema
+    description: >-
+      Semantic code graph MCP server for AI coding agents. Indexes codebases
+      into typed graphs (functions/types/modules as nodes;
+      CALLS/IMPORTS/DATAFLOW edges) with 40+ tools for call-chain tracing,
+      data-flow analysis, and semantic code search.
+    category: developer-tools
+    license: FSL-1.1-Apache-2.0
   - name: docker/hub-mcp
     github_id: docker/hub-mcp
     description: >-


### PR DESCRIPTION
## What

Adds [Grafema](https://github.com/Disentinel/grafema) to the **developer-tools** category.

## About Grafema

Grafema is a semantic code graph MCP server for AI coding agents. It indexes a codebase into a typed graph (functions, types, modules as nodes; CALLS/IMPORTS/DATAFLOW/EFFECTS as typed edges) and exposes 40+ MCP tools for call-chain tracing, data-flow analysis, semantic search, and invariant checking — so agents navigate code structure instead of reading files line by line.

- **npm**: `npm install -g grafema`
- **Transport**: stdio
- **License**: FSL-1.1-Apache-2.0
- **Platforms**: macOS (arm64/x64), Linux (arm64/x64)
- **GitHub**: https://github.com/Disentinel/grafema

## Notes

- Entry inserted in alphabetical order (after `delano/postman-mcp-server`, before `docker/hub-mcp`)
- Description wrapped to satisfy yamllint line-length ≤80 rule
- A previous PR (#253) was submitted from the Disentinel fork but had a yamllint CI failure (line too long). This PR fixes that issue with correct line wrapping from a fork with CI access.