### PR TITLE
Add project: seekstone

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1848,6 +1848,14 @@ projects:
       (95.4%).
     pypi_id: omega-memory
     category: knowledge-and-memory
+  - name: shaqmughal/seekstone
+    github_id: shaqmughal/seekstone
+    npm_id: seekstone
+    description: >-
+      Filesystem-direct Obsidian MCP server that gives Claude direct read/write
+      access to your Obsidian vault with no Obsidian app or plugin required.
+      Exposes 16 tools over stdio with roughly 575x smaller search payloads.
+    category: knowledge-and-memory
   - name: jagan-shanmugam/open-streetmap-mcp
     github_id: jagan-shanmugam/open-streetmap-mcp
     description:


### PR DESCRIPTION
Adds [Seekstone](https://github.com/shaqmughal/seekstone) to `projects.yaml` under the `knowledge-and-memory` category, per CONTRIBUTING (one project per PR; edit projects.yaml, not README).

Seekstone is a filesystem-direct Obsidian MCP server — direct read/write access to an Obsidian vault from disk, no Obsidian app or plugin required. Published on npm as `seekstone`; 16 tools over stdio.