### PR TITLE
Add project: mnemoverse/mcp-memory-server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1848,6 +1848,16 @@ projects:
       (95.4%).
     pypi_id: omega-memory
     category: knowledge-and-memory
+  - name: mnemoverse/mcp-memory-server
+    github_id: mnemoverse/mcp-memory-server
+    description: >-
+      MIT-licensed MCP server for Mnemoverse, a managed persistent-memory API
+      for AI agents. Write a fact once and recall it across Claude, Cursor,
+      VS Code, and ChatGPT over MCP; feedback re-ranks what helps and recall
+      fades by recency. Runs over stdio via
+      npx -y @mnemoverse/mcp-memory-server@latest.
+    npm_id: "@mnemoverse/mcp-memory-server"
+    category: knowledge-and-memory
   - name: jagan-shanmugam/open-streetmap-mcp
     github_id: jagan-shanmugam/open-streetmap-mcp
     description:


### PR DESCRIPTION
Adds Mnemoverse to the **knowledge-and-memory** category.

- Repo: https://github.com/mnemoverse/mcp-memory-server (MIT)
- npm: `@mnemoverse/mcp-memory-server` (stdio; `npx -y @mnemoverse/mcp-memory-server@latest`)
- Category: `knowledge-and-memory`

Mnemoverse is a managed persistent-memory API for AI agents. This MCP server is the public, MIT-licensed client; the underlying memory engine is a managed service. Write a fact once and recall it across Claude, Cursor, VS Code, and ChatGPT over MCP; feedback re-ranks what helps and recall fades by recency.

Not previously listed or suggested. Single project in this PR, per CONTRIBUTING.md.
