### PR TITLE
Add OffshoreProz Agent Company (finance-and-fintech)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,11 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: tcgtracker-boop/agent-company-mcp
+    github_id: tcgtracker-boop/agent-company-mcp
+    description: >-
+      Form a company for your AI agent — a Nevis LLC that owns the agent,
+      contains its liability, and proves its authority via an Agent Charter
+      (mandate, power of attorney, machine-readable mandate). Free
+      agent_company_diagnostic tool, no API key.
+    category: finance-and-fintech


### PR DESCRIPTION
Adds **OffshoreProz Agent Company** to `projects.yaml` under **finance-and-fintech**.

A hosted MCP server that forms a Nevis LLC to own an autonomous AI agent, contain its liability, and prove its authority via an Agent Charter (mandate, power of attorney, machine-readable mandate). Free `agent_company_diagnostic` tool, no API key.

Repo: https://github.com/tcgtracker-boop/agent-company-mcp

🤖 Generated with [Claude Code](https://claude.com/claude-code)
