### PR TITLE
Add project: Sipcode

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,11 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: Anuj7411/sipcode
+    github_id: Anuj7411/sipcode
+    npm_id: sipcode
+    description: >-
+      A PreToolUse hook and CLI for Claude Code that caps verbose tool output
+      and deduplicates same-session file re-reads to reduce context bloat, with
+      an MCP server exposing context-hygiene stats.
+    category: developer-tools


### PR DESCRIPTION
Adding Sipcode under the developer-tools category.

Sipcode is an open-source (MIT) PreToolUse hook and CLI for Claude Code that caps verbose tool output and deduplicates same-session file re-reads to reduce context bloat. It ships a 15-tool MCP server that exposes context-hygiene stats during a session.

- Repo: https://github.com/Anuj7411/sipcode
- npm: https://www.npmjs.com/package/sipcode

Added a single entry to projects.yaml per CONTRIBUTING (not the README). Checked that it was not already listed.