### PR TITLE
Add project: subsquid-labs/portal-mcp-server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,6 +1679,13 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: subsquid-labs/portal-mcp-server
+    github_id: subsquid-labs/portal-mcp-server
+    description: >-
+      MCP server for querying onchain data across EVM, Solana, Bitcoin,
+      Substrate, and Hyperliquid networks via the SQD Portal API — logs,
+      transactions, token transfers, OHLC, and wallet analytics.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
## Add project: subsquid-labs/portal-mcp-server

Submitted by the maintainers ([subsquid-labs](https://github.com/subsquid-labs)) of the project.

Adds the **SQD Portal MCP server** ([subsquid-labs/portal-mcp-server](https://github.com/subsquid-labs/portal-mcp-server)) under the `finance-and-fintech` category in `projects.yaml`.

### What it does
- Queries indexed onchain data across **EVM, Solana, Bitcoin, Substrate, and Hyperliquid** networks via the SQD Portal API.
- Exposes logs, transactions, token transfers, OHLC, and wallet/analytics data to LLM agents.

### How it runs
- Hosted remote Streamable-HTTP endpoint: `https://portal.sqd.dev/mcp`
- Locally via stdio (Docker image `subsquid/portal-mcp-server`)

### Checklist
- [x] Edited `projects.yaml` only (not the generated `README.md`).
- [x] Single project block, matching surrounding YAML formatting.
- [x] Used an existing category key (`finance-and-fintech`).
- [x] Verified the project is not already listed.