### PR TITLE
Add project: BuyWhere/buywhere-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2142,6 +2142,17 @@ projects:
       and more with real-time weather data, stock market information, and
       flexible JSON response modes.
     category: search-data-extraction
+  - name: BuyWhere/buywhere-mcp
+    github_id: BuyWhere/buywhere-mcp
+    npm_id: '@buywhere/mcp-server'
+    description: >-
+      Real-time product search and price-comparison MCP server for AI agents.
+      Indexes 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+
+      retailers in Singapore, SEA, and US. Exposes 7 tools (search_products,
+      get_product, compare_products, find_best_price, get_deals,
+      list_categories, find_similar). Free API key with no signup flow.
+    category: search-data-extraction
+
   - name: beelzebub-labs/beelzebub
     github_id: beelzebub-labs/beelzebub
     description: >-


### PR DESCRIPTION
## Add project: BuyWhere/buywhere-mcp

Adds BuyWhere MCP server to `projects.yaml` under the **search-data-extraction** category, per the contribution guidelines ("Add a project by modifying the projects.yaml").

### Format compliance
- `name`: `BuyWhere/buywhere-mcp`
- `github_id`: `BuyWhere/buywhere-mcp`
- `npm_id`: `@buywhere/mcp-server`
- `description`: ~700 chars, well within the 1000 char limit
- `category`: `search-data-extraction`

### About BuyWhere MCP
- **Coverage:** 11M+ products across Shopee, Lazada, Amazon, Walmart, and 20+ retailers in Singapore, SEA, and US
- **Tools:** `search_products`, `get_product`, `compare_products`, `find_best_price`, `get_deals`, `list_categories`, `find_similar`
- **Endpoints:** streamable-HTTP at `https://api.buywhere.ai/mcp`, stdio via `npx @buywhere/mcp-server`
- **Free API key** (no signup flow, 3-second registration via `POST /v1/auth/register`)
- **Open source** (MIT license)
- **MCP Registry listed:** `io.github.BuyWhere/buywhere-mcp@1.0.5`
- **Production traffic:** HTTP 200, weekly releases

### Why this fits `search-data-extraction`
- Core function is structured product data retrieval (not just a chatbot/search wrapper)
- Cross-merchant data extraction at scale (20+ retailers in one tool)
- Comparison/aggregation features fit the "Search & Data Extraction" category alongside brave-search, exa, serpapi

Let me know if the category should be different (e.g., `aggregators` or a new one) or if the description needs trimming.