### PR TITLE
Add Edgrapi (SEC EDGAR financials) to finance-and-fintech

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,10 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: paperandbeyond23-gif/edgrapi-skills
+    github_id: paperandbeyond23-gif/edgrapi-skills
+    description: >-
+      Clean SEC EDGAR company financials, ratios, filings and 10-K/10-Q narrative
+      sections as normalized JSON for 10,000+ US public companies. Hosted MCP
+      server (Streamable HTTP), free tier.
+    category: finance-and-fintech


### PR DESCRIPTION
Adds **Edgrapi** to `projects.yaml` under `finance-and-fintech`.

- Repo: https://github.com/paperandbeyond23-gif/edgrapi-skills
- Hosted MCP server: `https://api.edgrapi.com/mcp` (Streamable HTTP) — also on the Official MCP Registry as `io.github.paperandbeyond23-gif/edgrapi-skills`
- Clean SEC EDGAR company financials, ratios, filings and 10-K/10-Q narrative sections as normalized JSON for 10,000+ US public companies. Free tier.

Single entry added; YAML validated. Thanks for maintaining this list!