### PR TITLE
Add ShieldZCash/shieldz-mcp (finance-and-fintech)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -118,6 +118,12 @@ categories:
     subtitle: MCP servers for other tools and integrations
 
 projects:
+  - name: ShieldZCash/shieldz-mcp
+    github_id: ShieldZCash/shieldz-mcp
+    description: >-
+      Non-custodial crypto payments over MCP. Turn a wallet address into a
+      payment link, tip jar, or account-status check with no API key.
+    category: finance-and-fintech
   - name: 1mcp-app/agent
     github_id: 1mcp-app/agent
     description: >-


### PR DESCRIPTION
Adds [shieldz-mcp](https://github.com/ShieldZCash/shieldz-mcp): a non-custodial crypto payments MCP server. An agent turns a wallet address into a payment link, tip jar, or account-status check with no API key; funds settle directly to the wallet.