### PR TITLE
Add BankBridge — read-only bank access for AI agents

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1581,6 +1581,14 @@ projects:
       MCP to interface with multiple blockchains, staking, DeFi, swap, bridging,
       wallet management, DCA, Limit Orders, Coin Lookup, Tracking and more.
     category: finance-and-fintech
+  - name: bankbridge-money/bankbridge-plugin
+    github_id: bankbridge-money/bankbridge-plugin
+    homepage: https://bankbridge.money
+    description: >-
+      Read-only bank access for your AI agent. Hosted MCP server giving Claude,
+      ChatGPT, Cursor, Gemini, and Codex access to real bank accounts,
+      transactions, and investment holdings via Plaid. 12 tools.
+    category: finance-and-fintech
   - name: base/base-mcp
     github_id: base/base-mcp
     description: >-


### PR DESCRIPTION
Adds **BankBridge** to the Finance & Fintech section.

- Site: https://bankbridge.money
- Plugin repo: https://github.com/bankbridge-money/bankbridge-plugin
- MCP endpoint: \`https://bankbridge.money/api/mcp\` (streamable-http, MCP 2025-06-18)
- Auth: Bearer (\`bbk_...\`) or OAuth 2.1 with DCR + PKCE
- 12 read-only tools (balances, transactions, recurring charges, monthly cashflow, holdings, investment txns, etc.)
- $5/month per connected bank
- Zero financial-data persistence (live-fetch via a secure bank link flow)
- Also listed on the official MCP Registry as \`money.bankbridge/server\`

Entry inserted alphabetically after \`armorwallet/armor-crypto-mcp\`. Happy to revise the description length, category placement, or YAML shape if anything's off — thanks for maintaining the list!
