### PR TITLE
Add project: drumbeats-io/mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,14 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: drumbeats-io/mcp
+    github_id: drumbeats-io/mcp
+    npm_id: "@drumbeats/mcp"
+    homepage: https://drumbeats.io
+    description: >-
+      Operate Drumbeats monitoring from any AI client: create cron/heartbeat and
+      HTTP uptime monitors, check status pages, triage incidents, and run
+      HTTP/SSL/DNS diagnostics (no account required) in natural language. Ships an
+      npm/stdio package and a hosted remote at api.drumbeats.io/mcp.
+    category: monitoring
+    labels: ["monitoring", "uptime", "cron", "observability"]

--- a/projects.yaml
+++ b/projects.yaml
@@ -2589,7 +2589,7 @@ projects:
     description: >-
       Operate Drumbeats monitoring from any AI client: create cron/heartbeat and
       HTTP uptime monitors, check status pages, triage incidents, and run
-      HTTP/SSL/DNS diagnostics (no account required) in natural language. Ships an
-      npm/stdio package and a hosted remote at api.drumbeats.io/mcp.
+      HTTP/SSL/DNS diagnostics (no account required) in natural language.
+      Ships an npm/stdio package and a hosted remote at api.drumbeats.io/mcp.
     category: monitoring
     labels: ["monitoring", "uptime", "cron", "observability"]


### PR DESCRIPTION
Adds the official Drumbeats MCP server under the **monitoring** category.

- `github_id: drumbeats-io/mcp` (Apache-2.0)
- `npm_id: @drumbeats/mcp` · hosted remote at `https://api.drumbeats.io/mcp`
- Operates Drumbeats monitoring from any AI client: cron/heartbeat + HTTP uptime monitors, status-page checks, incident triage, and no-account HTTP/SSL/DNS diagnostics in natural language.

Added to `projects.yaml` per contributing guidelines (not README).