### PR TITLE
Add project: hushvert/mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,10 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: hushvert/mcp
+    github_id: hushvert/mcp
+    description: >-
+      File-conversion tools for AI agents: convert documents, images, audio,
+      video, archives and PDFs across formats via convert_file, convert_poll,
+      list_formats and check_usage.
+    category: other-tools-and-integrations


### PR DESCRIPTION
Adds hushvert/mcp under other-tools-and-integrations.

An MCP server that gives AI agents file-conversion tools (convert_file, convert_poll, list_formats, check_usage) for documents, images, audio, video, archives and PDFs. It runs browser-doable conversions locally and refuses to bill for them, using the hosted API only for conversions a browser cannot do.

- npm: @hushvert/mcp
- official registry: com.hushvert/mcp
- repo: https://github.com/hushvert/mcp

Edited projects.yaml only (README is auto-generated); YAML validated.