### PR TITLE
Add sessionmem -- local-first MCP server for persistent AI coding session memory

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1828,6 +1828,15 @@ projects:
       vector storage and local embeddings - no API keys or cloud services
       required.
     category: knowledge-and-memory
+  - name: catfish-1234/sessionmem
+    github_id: catfish-1234/sessionmem
+    npm_id: sessionmem
+    description: >-
+      Local-first MCP server that auto-injects compact session summaries into
+      AI coding assistants. Persistent memory across sessions with 85.6% token
+      reduction vs pasting full history. Zero config, no cloud, no API keys.
+      SQLite storage at ~/.sessionmem/memories.db.
+    category: knowledge-and-memory
   - name: topoteretes/cognee
     github_id: topoteretes/cognee
     description: >-


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] - [ ] Update a project
- [ ] - [ ] Remove a project
- [ ] - [ ] Add or update a category
- [ ] - [ ] Change configuration
- [ ] - [ ] Documentation
- [ ] - [ ] Other, please describe:
**Description:**

Adds [sessionmem](https://github.com/catfish-1234/sessionmem) to the knowledge-and-memory category.

sessionmem is a local-first MCP server that auto-injects compact session summaries into AI coding assistants (Claude Code, Cline, Cursor, etc.). It provides persistent memory across sessions with 85.6% token reduction vs pasting full history. Zero config, no cloud, no API keys. SQLite storage at ~/.sessionmem/memories.db.

Closes #247

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [ ] - [x] The project I want to add has at least 10 GitHub stars or is a noteworthy project.
- [ ] - [x] The project is not already in the list.