### PR TITLE
Add project: supplement-advisor-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -118,6 +118,15 @@ categories:
     subtitle: MCP servers for other tools and integrations
 
 projects:
+  - name: erinheit451/supplement-advisor-mcp
+    github_id: erinheit451/supplement-advisor-mcp
+    npm_id: supplement-advisor-mcp
+    description: >-
+      Evidence-graded dietary-supplement guidance: dosing ranges, best-absorbed
+      forms, drug-nutrient interactions, and cost-per-effective-dose. Every
+      recommendation traces to a PubMed source.
+    labels: ["nutrition", "health"]
+    category: bio
   - name: 1mcp-app/agent
     github_id: 1mcp-app/agent
     description: >-


### PR DESCRIPTION
Adds `supplement-advisor-mcp` under the **bio** category.

An MCP server for evidence-graded dietary-supplement guidance: dosing ranges, best-absorbed forms, drug-nutrient interactions, and cost-per-effective-dose — every recommendation traces to a PubMed source.

- npm: https://www.npmjs.com/package/supplement-advisor-mcp (v1.1.0)
- GitHub: https://github.com/erinheit451/supplement-advisor-mcp
- Listed in the Official MCP Registry as `com.verifiedsupplementdata/supplement-advisor-mcp`
- Tools: recommend_supplement, compare_forms, check_interactions, get_dosage, classify_form

Confirmed not already present in projects.yaml. Follows the yaml entry format; category `bio` (Biology, Medicine and Bioinformatics).