### PR TITLE
Add project: scribo-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,6 +1679,13 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: causa-prima-ai/scribo-mcp
+    github_id: causa-prima-ai/scribo-mcp
+    description: >-
+      Generate free, EN 16931-compliant e-invoices (German ZUGFeRD & XRechnung,
+      plus Factur-X, Peppol BIS and Spanish Facturae) or a plain US PDF straight
+      from your AI assistant. Hosted MCP server; the sender's email is the login.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
Adds **Scribo** (`causa-prima-ai/scribo-mcp`) to the **Finance & Fintech** category.

Scribo is a free, AI-native e-invoicing tool. Its hosted MCP server (`https://scribo.causaprima.ai/mcp`, streamable-http) lets an AI assistant generate EN 16931-compliant e-invoices — German ZUGFeRD (B2B) and XRechnung (B2G) are live today, with Factur-X, Peppol BIS and Spanish Facturae on the way — or a plain US PDF. Free forever; the sender's email is the login.

- Repo: https://github.com/causa-prima-ai/scribo-mcp
- Website: https://scribo.causaprima.ai
- Also listed in the official MCP Registry as `io.github.causa-prima-ai/scribo`.

Single project added to `projects.yaml` under `finance-and-fintech`, following the existing entry format.