### PR TITLE
Add cocoindex-io/cocoindex-code to projects.yaml

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -118,6 +118,12 @@ categories:
     subtitle: MCP servers for other tools and integrations
 
 projects:
+  - name: cocoindex-io/cocoindex-code
+    github_id: cocoindex-io/cocoindex-code
+    description: >-
+      AST/tree-sitter code search MCP server that indexes a codebase and
+      returns compact, relevant snippets to reduce coding-agent context usage.
+    category: coding-agents
   - name: 1mcp-app/agent
     github_id: 1mcp-app/agent
     description: >-


### PR DESCRIPTION
Adds [cocoindex-io/cocoindex-code](https://github.com/cocoindex-io/cocoindex-code) to `projects.yaml` under the `coding-agents` category.

AST / tree-sitter code search MCP server that indexes a codebase and returns compact, relevant snippets to reduce coding-agent context usage. Apache-2.0, Python, ~2.5k stars. Disclosure: I'm a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)