### PR TITLE
Add posthell (social-media)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2280,6 +2280,14 @@ projects:
       Browse Reddit posts, search content, and analyze user activity without API
       keys. Works out-of-the-box with Claude Desktop.
     category: social-media
+  - name: Rohan27s/posthell-mcp
+    github_id: Rohan27s/posthell-mcp
+    homepage: https://www.posthell.com/mcp
+    description: >-
+      Hosted social media scheduler for AI agents: remote Streamable HTTP
+      server (API key) that shapes notes into posts, queues drafts for human
+      approval, reads growth analytics, and publishes to 15 networks.
+    category: social-media
   - name: r-huijts/strava-mcp
     github_id: r-huijts/strava-mcp
     description: >-


### PR DESCRIPTION
Adds posthell, a hosted social media scheduler for AI agents. Remote Streamable HTTP MCP server at https://www.posthell.com/api/mcp (per-user API key), draft-into-human-approval by default, 15 networks. Also in the official MCP registry as io.github.Rohan27s/posthell. Docs: https://www.posthell.com/mcp