### PR TITLE
Add: hbhqq9/bde-score (Finance & Fintech)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,6 +1679,13 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: hbhqq9/bde-score
+    github_id: hbhqq9/bde-score
+    description: >-
+      Score stocks across US, HK, CN markets with one query. 6 MCP tools for
+      BDE scoring, stock analysis, multi-market comparison, screening, sector
+      analysis, and ESG scoring.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
Adding BDE Score MCP server to the finance-and-fintech category.

BDE Score is a remote MCP server that provides stock scoring and analysis across US, HK, and CN markets with 6 tools: BDE scoring, stock analysis, multi-market comparison, screening, sector analysis, and ESG scoring.

- GitHub: https://github.com/hbhqq9/bde-score
- Transport: Streamable HTTP (remote server)
- Auth: None (authless)
- Listed on Official MCP Registry: io.github.hbhqq9/bde-score v1.0.1