### PR TITLE
Add Tap — authenticated browser MCP

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -369,6 +369,15 @@ projects:
       navigate pages, fill forms, extract data, handle authentication, and
       automate any website via natural language
     category: browser-automation
+  - name: Tap
+    github_id: LeonTing1010/tap
+    description: >-
+      An authenticated browser MCP that drives your OWN logged-in Chrome so
+      credentials stay local; compiles a task into a deterministic .plan.json
+      program (closed 18-op instruction set) replayed at zero LLM tokens.
+    npm_id: "@taprun/cli"
+    pypi_id: taprun
+    category: browser-automation
   - name: alexei-led/aws-mcp-server
     github_id: alexei-led/aws-mcp-server
     description: >-


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project

**Description:**

Adds **Tap** (`LeonTing1010/tap`) to the **browser-automation** category — an authenticated browser MCP that drives your OWN logged-in Chrome so credentials stay local, and compiles a task into a deterministic `.plan.json` program (closed 18-op instruction set) replayed at zero LLM tokens.

Unlike cloud browser MCPs, Tap runs in your own browser and reuses your live session, so credentials never cross a trust boundary; once a task is compiled it replays mechanically with no model or API key involved.

- Repo: https://github.com/LeonTing1010/tap
- Website: https://taprun.dev
- npm: `@taprun/cli` · PyPI: `taprun`

The entry was added only to `projects.yaml`, matching the exact schema and field order of neighboring entries (name → github_id → description → npm_id/pypi_id → category). Verified the file still parses as valid YAML and the new lines stay within the 80-char yamllint limit.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
