### PR TITLE
Add project: mirabello-consultancy/mcp-server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,6 +1679,13 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: mirabello-consultancy/mcp-server
+    github_id: mirabello-consultancy/mcp-server
+    description: >-
+      Investment migration, tax residency & wealth-protection data — CBI/RBI
+      programmes, HNWI tax profiles, trusts/succession, and qualifying real
+      estate, with an origin-aware migration path planner.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
Adds the Mirabello Consultancy MCP server to the finance-and-fintech category.

- **Repo:** https://github.com/mirabello-consultancy/mcp-server
- **Live remote endpoint:** https://mcp.mirabelloconsultancy.com/ (Streamable-HTTP)
- **What it is:** 44 tools covering citizenship/residency-by-investment (CBI/RBI) programme data, HNWI tax & wealth-protection profiles, trust/succession jurisdictions, qualifying real estate, and an origin-aware migration path planner.
- Already listed on the official MCP Registry, Glama, PulseMCP, mcp.so, and Smithery.

Followed CONTRIBUTING.md: single project added to `projects.yaml` only, individual PR, title format `Add project: project-name`.