### PR TITLE
Add RunComfy MCP (multimedia-process)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1965,6 +1965,7 @@ projects:
     category: multimedia-process
   - name: runcomfy-com/runcomfy-mcp
     github_id: runcomfy-com/runcomfy-mcp
+    homepage: "https://www.runcomfy.com"
     description: >-
       Official remote MCP server for the RunComfy Serverless API (ComfyUI):
       create and manage GPU deployments, run async inference, and retrieve
@@ -2589,3 +2590,4 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+

--- a/projects.yaml
+++ b/projects.yaml
@@ -1963,6 +1963,13 @@ projects:
       convenient, through the dialogue to achieve the local video search,
       tailoring, stitching, playback and other functions
     category: multimedia-process
+  - name: runcomfy-com/runcomfy-mcp
+    github_id: runcomfy-com/runcomfy-mcp
+    description: >-
+      Official remote MCP server for the RunComfy Serverless API (ComfyUI):
+      create and manage GPU deployments, run async inference, and retrieve
+      image/video results.
+    category: multimedia-process
   - name: Aas-ee/open-webSearch
     github_id: Aas-ee/open-webSearch
     description: >-


### PR DESCRIPTION
Adds **runcomfy-com/runcomfy-mcp** — the official remote MCP server for the RunComfy Serverless API (ComfyUI): manage GPU deployments + run async image/video inference.

- Endpoint: `https://mcp.runcomfy.com/mcp` · Registry: `io.github.runcomfy-com/runcomfy-mcp`
- Added to `projects.yaml` under **multimedia-process**.