### PR TITLE
Add CatchAll (NewsCatcher) MCP server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -118,6 +118,13 @@ categories:
     subtitle: MCP servers for other tools and integrations
 
 projects:
+  - name: Newscatcher/catchall-mcp
+    github_id: Newscatcher/catchall-mcp
+    description: >-
+      Recall-first web search API for comprehensive real-world event retrieval,
+      finding every relevant event across the open web (not just the top results),
+      returned as structured, deduplicated data.
+    category: search-data-extraction
   - name: 1mcp-app/agent
     github_id: 1mcp-app/agent
     description: >-

--- a/projects.yaml
+++ b/projects.yaml
@@ -121,9 +121,9 @@ projects:
   - name: Newscatcher/catchall-mcp
     github_id: Newscatcher/catchall-mcp
     description: >-
-      Recall-first web search API for comprehensive real-world event retrieval,
-      finding every relevant event across the open web (not just the top results),
-      returned as structured, deduplicated data.
+      Recall-first web search API for comprehensive real-world event
+      retrieval. Finds every relevant event across the open web (not just
+      the top results), returned as structured, deduplicated data.
     category: search-data-extraction
   - name: 1mcp-app/agent
     github_id: 1mcp-app/agent


### PR DESCRIPTION
Adds **CatchAll by NewsCatcher** to Search & Data Extraction — a recall-first web search API for comprehensive real-world event retrieval.

- Repo: https://github.com/Newscatcher/catchall-mcp
- Hosted MCP: https://catchall-mcp.newscatcherapi.com/mcp
- Also in the official MCP registry as com.newscatcherapi/catchall.