### PR TITLE
Add AgentServices — x402-paid crypto data APIs with 37 MCP tools

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,6 +1679,13 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: vbkotecha/aiservices-api
+    github_id: vbkotecha/aiservices-api
+    description: >-
+      AgentServices — 54-service paid API platform for AI agents with x402
+      on-chain payments. Crypto market data, DeFi analytics, trading indicators,
+      onchain intelligence, and MCP server with 37 tools.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
## Summary

Add AgentServices to the Finance & Fintech category.

**AgentServices** is a production x402-paid API platform for AI agents with:
- 54 services across crypto market data, DeFi analytics, trading indicators, onchain intelligence
- 97 API paths, 41 x402-paid endpoints  
- MCP server with 37 tools (protocol 2026-07-28 compliant)
- On-chain USDC payments via x402 protocol on Base (eip155:8453)
- Live at https://agentservices.to/health

**GitHub:** https://github.com/vbkotecha/aiservices-api
**Website:** https://agentservices.to
**Category:** Finance & Fintech