### PR TITLE
Add project: find-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -219,6 +219,13 @@ projects:
       scale—centralize tool discovery, access controls, call prioritization, and
       usage tracking to simplify agent workflows.
     category: aggregators
+  - name: agentage/find-mcp
+    github_id: agentage/find-mcp
+    description: >-
+      Search 17,000+ MCP servers synced from the official MCP registry, over
+      remote Streamable HTTP or stdio via npm.
+    npm_id: "@agentage/find-mcp"
+    category: aggregators
   - name: abhiemj/manim-mcp-server
     github_id: abhiemj/manim-mcp-server
     description: A local MCP server that generates animations using Manim.


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Adds Find MCP (agentage/find-mcp) to the `aggregators` category in `projects.yaml`.

Find MCP is an MCP server for discovering other MCP servers. It searches the agentage MCP Catalog: 17,000+ servers synced from the official MCP registry (registry.modelcontextprotocol.io).

- GitHub: https://github.com/agentage/find-mcp
- npm: `@agentage/find-mcp` (stdio: `npx -y @agentage/find-mcp`)
- Remote: Streamable HTTP at https://catalog.agentage.io/mcp (no auth needed for search)
- Official registry entry: `io.agentage/find-mcp`
- Web UI: https://catalog.agentage.io/mcp

Disclosure: I maintain Find MCP.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
