### PR TITLE
Add project: StarMeet MCP Server

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -239,6 +239,13 @@ projects:
       Provides comprehensive and accurate Bazi (Chinese Astrology) charting and
       analysis
     category: art-and-culture
+  - name: edestory/mcp-starmeet
+    github_id: edestory/mcp-starmeet
+    npm_id: "@edestory/mcp-starmeet"
+    description: >-
+      Vedic astrology (Jyotish) tools for AI assistants — Kundali birth-chart
+      preview, daily Panchang, and Nakshatra profiles via the star-meet.com API.
+    category: art-and-culture
   - name: cswkim/discogs-mcp-server
     github_id: cswkim/discogs-mcp-server
     description: MCP server to interact with the Discogs API


### PR DESCRIPTION
Adds **StarMeet MCP Server** ([edestory/mcp-starmeet](https://github.com/edestory/mcp-starmeet)) under `art-and-culture` (alongside the existing Bazi astrology server).

It provides Vedic astrology (Jyotish) tools to AI assistants — Kundali birth-chart preview, daily Panchang, and Nakshatra profiles — via the free [star-meet.com](https://star-meet.com) API. Published on npm as `@edestory/mcp-starmeet`; MIT-licensed; claimed on Glama with quality score A.

- `name`/`github_id`: edestory/mcp-starmeet
- `npm_id`: @edestory/mcp-starmeet
- `category`: art-and-culture

Not previously present in projects.yaml (checked). One project per PR per CONTRIBUTING.md.