### PR TITLE
Add FlowCastle (Telegram bot builder MCP server)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -689,6 +689,12 @@ projects:
       channels, groups), retrieving messages, sending messages and handling read
       status.
     category: communication
+  - name: FlowCastle/telegram-bot-templates
+    github_id: FlowCastle/telegram-bot-templates
+    description: >-
+      Build, edit, and deploy Telegram bots on FlowCastle's hosted visual flow
+      platform. Remote Streamable HTTP MCP server with ready-made bot templates.
+    category: communication
   - name: hannesrudolph/imessage-query-fastmcp-mcp-server
     github_id: hannesrudolph/imessage-query-fastmcp-mcp-server
     description: >-


### PR DESCRIPTION
Adds `FlowCastle/telegram-bot-templates` to the communication category — build, edit, and deploy Telegram bots on [FlowCastle](https://flowcastle.ai)'s hosted visual flow platform. Remote Streamable HTTP MCP server, published in the official MCP Registry as `ai.flowcastle/flowcastle` ([server.json](https://github.com/FlowCastle/telegram-bot-templates/blob/main/mcp/server.json)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)