### PR TITLE
Add project: perwinroth/cosyhotels

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,11 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: perwinroth/cosyhotels
+    github_id: perwinroth/cosyhotels
+    description: >-
+      Got Cosy hosted MCP server (https://gotcosy.com/api/mcp): about 6,300
+      independent hotels scored 0-10 for cosiness and warmth from guest reviews
+      and photos, with evidence signals and verified booking links. Streamable
+      HTTP, no API key required, read-only.
+    category: travel-and-transportation


### PR DESCRIPTION
Adds the Got Cosy hosted MCP server under travel-and-transportation.

- name and github_id: perwinroth/cosyhotels (the MCP server source lives in this repo at src/lib/mcp/server.ts)
- Live endpoint: https://gotcosy.com/api/mcp (Streamable HTTP, stateless, no auth or API key)
- Manifest: https://gotcosy.com/mcp.json
- Tools: find_cosy_hotels, get_hotel_feeling. Data: about 6,300 independent hotels scored 0-10 for cosiness and warmth from guest reviews and photos, with verified booking links. Free, read-only.

Endpoint verified working before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)