### PR TITLE
Add Agent360dk/browser-mcp to browser-automation

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -313,6 +313,13 @@ projects:
     github_id: BrowserMCP/mcp
     description: Automate your local Chrome browser
     category: browser-automation
+  - name: Agent360dk/browser-mcp
+    github_id: Agent360dk/browser-mcp
+    description: >-
+      Control your real, already-logged-in Chrome from any AI agent. Works on
+      2FA- and login-gated sites where headless browsers get blocked. 34 tools,
+      MIT, 100% local.
+    category: browser-automation
   - name: kontext-dev/browser-use-mcp-server
     github_id: kontext-dev/browser-use-mcp-server
     description: >-


### PR DESCRIPTION
Adds **Browser MCP by Agent360** to the browser-automation category.

- Repo: https://github.com/Agent360dk/browser-mcp (MIT, actively maintained — last commit today)
- npm: `@agent360/browser-mcp`
- Official MCP registry: `io.github.Agent360dk/browser-mcp`

Chrome extension + local stdio MCP server that drives your **real, already-logged-in Chrome** (not a headless/isolated browser), so it works on 2FA- and login-gated sites where headless automation gets blocked. 34 tools, 100% local, works with Claude Code, Cursor, VS Code agent mode, Codex CLI and ZCode.

Note: the list already has `BrowserMCP/mcp` marked inactive (no commits since 2025-04-24) — this is a separate, unaffiliated, actively-maintained project with a similar name, added in the same category for people looking for a maintained option.

Added to `projects.yaml` per CONTRIBUTING; single entry.