### PR TITLE
Add SysKnife to the security category

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,11 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: lacs-project/sysknife
+    github_id: lacs-project/sysknife
+    description: >-
+      Security-hardened MCP server for Linux system administration. The agent
+      emits 189 typed actions instead of shell strings, with an Ed25519-signed
+      hash-chain audit log, one-time TTL approval receipts, and automatic
+      rollback. Works with Claude Code, Cursor, and Codex.
+    category: security


### PR DESCRIPTION
Adds **SysKnife** to **the security category**.

SysKnife is a security-hardened MCP server for Linux system administration: the agent emits 189 **typed actions** instead of shell strings, a privileged daemon executes only what you approve via one-time TTL receipts, every action is written to an Ed25519-signed hash-chain audit log (public-key verifiable), with automatic rollback on atomic hosts. Works with Claude Code, Cursor, and Codex CLI. Rust, MIT. Repo: https://github.com/lacs-project/sysknife

Single entry, follows the list format, working public link.
