### PR TITLE
Add Kilo IoT platform (new Industrial & IoT category)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -75,6 +75,9 @@ categories:
   - category: marketing
     title: Marketing
     subtitle: MCP servers for marketing
+  - category: industrial-and-iot
+    title: Industrial & IoT
+    subtitle: MCP servers for industrial equipment, IoT platforms and operational technology
   - category: monitoring
     title: Monitoring
     subtitle: MCP servers for monitoring
@@ -313,6 +316,14 @@ projects:
     github_id: BrowserMCP/mcp
     description: Automate your local Chrome browser
     category: browser-automation
+  - name: Kiloiot/kilo-mcp
+    github_id: Kiloiot/kilo-mcp
+    description: >-
+      Remote MCP server for the Kilo IoT platform. Read devices and telemetry, provision
+      hardware, deploy and simulate automation rules, work alarms and dashboards, and send
+      commands to real equipment, authorized by the user's own sign-in.
+    category: industrial-and-iot
+    homepage: https://kiloiot.io
   - name: kontext-dev/browser-use-mcp-server
     github_id: kontext-dev/browser-use-mcp-server
     description: >-


### PR DESCRIPTION
Adds **Kilo IoT** — a hosted remote MCP server for a commercial IoT platform. Connected clients read devices and telemetry, provision hardware, build/simulate/deploy rules-engine automation, work the alarm queue, and send commands to real equipment. OAuth 2.1 with dynamic client registration; the connection carries the signed-in user's own permissions.

- Repo: https://github.com/Kiloiot/kilo-mcp
- Homepage: https://kiloiot.io
- Endpoint: `https://mcp-auth.kiloiot.io/mcp` (Streamable HTTP)
- Also listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.kiloiot) as `io.kiloiot/kilo`

**Note on the new category:** there was no fitting bucket — `monitoring` undersells it and `embedded-system` is wrong for a cloud platform. I added `industrial-and-iot`, matching the "Industrial & IoT" category the upstream punkpeye list already uses, so the taxonomies stay aligned. Happy to drop the category and file it under `monitoring` instead if you'd rather not grow the list.

`projects.yaml` parses clean (406 projects, 35 categories).