### PR TITLE
Add Chirp (new Home Automation category)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -69,6 +69,9 @@ categories:
   - category: location-services
     title: Location Services
     subtitle: MCP servers for location services and geospatial data
+  - category: home-automation
+    title: Home Automation
+    subtitle: MCP servers for smart home devices and home automation platforms
   - category: knowledge-and-memory
     title: Knowledge & Memory
     subtitle: MCP servers for knowledge graphs and memory management
@@ -816,6 +819,14 @@ projects:
       DICOM integration to query, read, and move medical images and reports from
       PACS and other DICOM compliant systems.
     category: databases
+  - name: chirpwireless/chirp-mcp
+    github_id: chirpwireless/chirp-mcp
+    description: >-
+      Remote MCP server for the Chirp home automation platform. Ask an AI app which sensors
+      have gone quiet, what set off an alert or how cold the garage got, add sensors, review
+      automations, and send commands to devices in your own home.
+    category: home-automation
+    homepage: https://chirpwireless.io
   - name: chroma-core/chroma-mcp
     github_id: chroma-core/chroma-mcp
     description: >-


### PR DESCRIPTION
Adds **Chirp** — a hosted remote MCP server for a home automation platform. It points an AI app at the user's own home: which sensors have gone quiet, what set off last night's alert, how cold the garage got, plus adding sensors, reviewing automations, pulling dashboard data and sending commands to devices.

- Repo: https://github.com/chirpwireless/chirp-mcp
- Homepage: https://chirpwireless.io
- Endpoint: `https://mcp-auth.chirpwireless.io/mcp` (Streamable HTTP)
- Also listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.chirpwireless) as `io.chirpwireless/chirp`

**Note on the new category:** nothing existing fits a smart-home server, so I added `home-automation` — the same category name the upstream punkpeye list uses, keeping the taxonomies aligned. Glad to file it under `other-tools-and-integrations` instead if you'd prefer not to add a category.

`projects.yaml` parses clean.