### PR TITLE
Add kudosity/mcp to communication

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -713,6 +713,14 @@ projects:
     github_id: korotovsky/slack-mcp-server
     description: The most powerful MCP server for Slack Workspaces.
     category: communication
+  - name: kudosity/mcp
+    github_id: kudosity/mcp
+    description: >-
+      Official Kudosity server for SMS, MMS and WhatsApp messaging. Send
+      messages, pull delivery reports and replies, manage contacts and contact
+      lists, configure webhooks, check account balance, and discover the live
+      API at runtime.
+    category: communication
   - name: lharries/whatsapp-mcp
     github_id: lharries/whatsapp-mcp
     description: >-


### PR DESCRIPTION
Adds [kudosity/mcp](https://github.com/kudosity/mcp) to the `communication` category.

- **Repo:** https://github.com/kudosity/mcp (MIT, CI)
- **npm:** [`kudosity-mcp`](https://www.npmjs.com/package/kudosity-mcp) — `npx -y kudosity-mcp`
- **Official MCP registry:** [`com.kudosity/mcp`](https://registry.modelcontextprotocol.io/v0/servers?search=com.kudosity/mcp), domain-verified via DNS

Official first-party server from Kudosity (Australian messaging provider). 19 named tools covering SMS/MMS/WhatsApp send, delivery reports and replies, contact and contact-list CRUD, webhooks, account balance, and runtime API discovery.

Inserted in alphabetical position between `korotovsky/slack-mcp-server` and `lharries/whatsapp-mcp`. `projects.yaml` parses cleanly and the category matches an existing one — I left out `npm_id` since no other entry uses it and the config sets `generate_install_hints: false`.