### PR TITLE
Add Adlicio customer research MCP server (marketing)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2582,3 +2582,11 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: adlicio
+    github_id: daniel-ddtech/commentscraper-cli
+    homepage: https://tryadlicio.com/mcp
+    description: >-
+      Customer-voice research MCP. Scrape comments and reviews from Reddit,
+      YouTube, Amazon, TikTok, and 25+ platforms, then rank them into ad
+      angles and hooks for marketers.
+    category: marketing


### PR DESCRIPTION
Adds Adlicio to the marketing category.

Adlicio is a remote MCP server (streamable HTTP at https://mcp.tryadlicio.com/mcp, OAuth, free tier) that scrapes customer comments and reviews from Reddit, YouTube, Amazon, TikTok, app stores, and 25+ other platforms, then ranks them into ad angles and hooks. Listed in the official MCP registry as `com.tryadlicio/adlicio`. The github_id points to the public CLI/MCP docs repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FzumMsxJeHuWcBFNX9uN1s