### PR TITLE
Add bytebase/dbhub to databases

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -798,6 +798,12 @@ projects:
       Baserow database integration with table search, list, and row create,
       read, update, and delete capabilities.
     category: databases
+  - name: bytebase/dbhub
+    github_id: bytebase/dbhub
+    description: >-
+      Token efficient, zero-dependency database MCP server for Postgres, MySQL,
+      SQL Server, MariaDB, SQLite.
+    category: databases
   - name: Canner/wren-engine
     github_id: Canner/wren-engine
     description:


### PR DESCRIPTION
Adds [DBHub](https://github.com/bytebase/dbhub) to the Databases category.

DBHub is a database MCP server that reaches Postgres, MySQL, SQL Server, MariaDB, and SQLite through one connector. It exposes just two tools (schema search and SQL execution) to keep the agent's context window small, and ships read-only mode, row limits, and query timeouts as defaults.

- Repo: https://github.com/bytebase/dbhub
- npm: `@bytebase/dbhub`
- Official MCP Registry: `io.github.bytebase/dbhub`
- License: MIT

Description is taken verbatim from the repository. Disclosure: I work at Bytebase, who maintain DBHub.