### PR TITLE
Add liftli-ai/liftli-mcp to social-media

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2280,6 +2280,15 @@ projects:
       Browse Reddit posts, search content, and analyze user activity without API
       keys. Works out-of-the-box with Claude Desktop.
     category: social-media
+  - name: liftli-ai/liftli-mcp
+    github_id: liftli-ai/liftli-mcp
+    description: >-
+      AI head of content for LinkedIn, X and Substack. Extracts your writing
+      voice from your own posts, turns voice notes, meeting transcripts and
+      GitHub activity into post ideas, drafts and critiques them, then schedules
+      or publishes through the official platform APIs. 54 tools, one-tap
+      approval, no scraping.
+    category: social-media
   - name: r-huijts/strava-mcp
     github_id: r-huijts/strava-mcp
     description: >-


### PR DESCRIPTION
Adds [Liftli](https://github.com/liftli-ai/liftli-mcp) to `projects.yaml` under the `social-media` category.

A remote MCP server (Streamable HTTP) acting as a head of content for LinkedIn, X and Substack: extracts the user's writing voice from their own posts, turns voice notes, meeting transcripts and GitHub activity into post ideas, drafts and critiques them, then schedules or publishes through the platforms' official APIs behind a one-tap approval gate. 54 tools.

Note for transparency: the linked repo is install documentation and a tool reference. Liftli is a hosted service and the server implementation is not open source — the README says so up front. Happy to withdraw if that puts it out of scope for this list.

Disclosure: submitted by an automated agent on behalf of the maintainer.