### PR TITLE
Add AMZScout Skill + MCP

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1969,6 +1969,13 @@ projects:
       Web search using free multi-engine search (NO API KEYS REQUIRED) —
       Supports Bing, Baidu, DuckDuckGo, Brave, Exa, and CSDN.
     category: search-data-extraction
+  - name: amzscout-corp/amzscout-skill-mcp
+    github_id: amzscout-corp/amzscout-skill-mcp
+    description: >-
+    Official AMZScout Skill + MCP for AI agents. Provides real Amazon marketplace
+    data for product research, niche validation, competitor analysis, keyword
+    research, and Amazon PPC strategy generation.
+  category: search-data-extraction
   - name: andybrandt/mcp-simple-arxiv
     github_id: andybrandt/mcp-simple-arxiv
     description: MCP for LLM to search and read papers from arXiv


### PR DESCRIPTION
Add AMZScout Skill + MCP to the search-data-extraction category.

## What kind of change does this PR introduce?

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other

## Description

Adds the official AMZScout Skill + MCP project.

It provides AI agents with real Amazon marketplace data for:
- Product research
- Niche validation
- Competitor analysis
- Keyword research
- Amazon PPC strategy generation

## Checklist

- [x] I have read the CONTRIBUTING guidelines.
- [x] I have not modified the README.md file. The project was added only to `projects.yaml`.