### PR TITLE
Add Aidelly (social-media)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2267,6 +2267,14 @@ projects:
       and runs locally via Docker or as a standalone binary for fast, automated
       vetting.
     category: security
+  - name: Aidelly/claude-plugin
+    github_id: Aidelly/claude-plugin
+    homepage: https://www.aidelly.ai
+    description: >-
+      Agent-operated social media management for agencies: publish, schedule,
+      approve, and analyze posts across 11 networks. Remote MCP server with
+      OAuth 2.1 one-click sign-in (www.aidelly.ai).
+    category: social-media
   - name: HagaiHen/facebook-mcp-server
     github_id: HagaiHen/facebook-mcp-server
     description: >-


### PR DESCRIPTION
Adds Aidelly to projects.yaml (social-media). Vendor-maintained remote MCP server, listed on the official MCP Registry as io.github.wilzer/aidelly. Homepage: https://www.aidelly.ai — PR prepared by an AI agent on behalf of the Aidelly maintainer.