### PR TITLE
Add seatswiper-mcp (restaurant reservation MCP connector)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2334,6 +2334,13 @@ projects:
     github_id: openbnb-org/mcp-server-airbnb
     description: Provides tools to search Airbnb and get listing details.
     category: travel-and-transportation
+  - name: gyatesofficial/seatswiper-mcp
+    github_id: gyatesofficial/seatswiper-mcp
+    description: >-
+      Books hard-to-get restaurant reservations on your own Resy, SevenRooms,
+      or OpenTable account the moment a table opens or someone cancels. Remote
+      MCP connector (com.seatswiper/booking).
+    category: travel-and-transportation
   - name: github/github-mcp-server
     github_id: github/github-mcp-server
     description: >-


### PR DESCRIPTION
Adds seatswiper-mcp to projects.yaml under travel-and-transportation.

SeatSwiper is a remote MCP connector that books hard-to-get restaurant reservations on your own Resy, SevenRooms, or OpenTable account the moment a table opens or someone cancels. It books on the user's own account and in their name; nothing is resold, transferred, or listed.

- Repo: https://github.com/gyatesofficial/seatswiper-mcp
- Official MCP registry: com.seatswiper/booking (active) at https://registry.modelcontextprotocol.io/v0/servers?search=seatswiper
- Endpoint: https://www.seatswiper.com/api/mcp (streamable-http, OAuth 2.1 with DCR + PKCE)
- Category: travel-and-transportation

Honest limitation: it books on Resy, SevenRooms, and OpenTable only and grabs an opening, it does not guarantee a table.