### PR TITLE
Add project: LambdaTest/mcp-server-guide

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1272,11 +1272,13 @@ projects:
     category: developer-tools
   - name: LambdaTest/mcp-server-guide
     github_id: LambdaTest/mcp-server-guide
+    homepage: https://www.testmuai.com/mcp/
+    docs_url: https://www.testmuai.com/support/docs/testmu-mcp-server/
     description: >-
       Run, debug, and triage tests from your IDE using natural language.
-      Connects MCP clients to TestMu AI (formerly LambdaTest) for test
-      orchestration, failure triage, visual regression analysis, and
-      accessibility audits.
+      Connects MCP clients to the hosted TestMu AI (formerly LambdaTest) server
+      at https://mcp.lambdatest.com/mcp for test orchestration, failure triage,
+      visual regression analysis, and accessibility audits.
     category: developer-tools
   - name: lamemind/mcp-server-multiverse
     github_id: lamemind/mcp-server-multiverse

--- a/projects.yaml
+++ b/projects.yaml
@@ -1270,6 +1270,14 @@ projects:
     description:
       Token-efficient access to OpenAPI/Swagger specs via MCP Resources.
     category: developer-tools
+  - name: LambdaTest/mcp-server-guide
+    github_id: LambdaTest/mcp-server-guide
+    description: >-
+      Run, debug, and triage tests from your IDE using natural language.
+      Connects MCP clients to TestMu AI (formerly LambdaTest) for test
+      orchestration, failure triage, visual regression analysis, and
+      accessibility audits.
+    category: developer-tools
   - name: lamemind/mcp-server-multiverse
     github_id: lamemind/mcp-server-multiverse
     description: >-


### PR DESCRIPTION
Adding the TestMu AI (formerly LambdaTest) MCP Server to the list.

**Repo:** https://github.com/LambdaTest/mcp-server-guide
**Homepage:** https://www.testmuai.com/mcp/
**Docs:** https://www.testmuai.com/support/docs/testmu-mcp-server/
**Hosted endpoint:** `https://mcp.lambdatest.com/mcp`
**Category:** `developer-tools`

Connects any MCP-compatible client to the TestMu AI platform so tests can be run, debugged and triaged in natural language from the IDE. Tools cover HyperExecute test orchestration, automation failure triage (command/network/console logs), SmartUI visual regression analysis, WCAG accessibility audits, and test management.

The server is hosted — there is nothing to self-host or install. Auth is over OAuth. Supported clients include Cursor, Claude Code, Claude Desktop, GitHub Copilot, Codex, Windsurf, Cline, Continue, Zed and JetBrains AI Assistant, with an `mcp-remote` fallback for STDIO-only clients.

Note on the endpoint URL: `https://mcp.lambdatest.com/mcp` is the MCP transport endpoint and returns `401` to an unauthenticated browser request, so it is referenced in the description rather than set as `homepage`/`docs_url` — both of those point at pages that return `200`.

Checklist:
- [x] The project was not already added or suggested to this list
- [x] Only `projects.yaml` was modified
- [x] Single project in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)