### PR TITLE
Add project: frankki-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -754,6 +754,14 @@ projects:
       An MCP server for Inbox Zero. Adds functionality on top of Gmail like
       finding out which emails you need to reply to or need to follow up on.
     category: communication
+  - name: datPascal/frankki-mcp
+    github_id: datPascal/frankki-mcp
+    description: >-
+      Send a real, printed letter or registered mail to a physical address
+      anywhere in the world in one tool call. Compose, price, send, track, with
+      an explicit approval step before anything is posted. Hosted remote server
+      with OAuth 2.1 and DCR, German compliance built in.
+    category: communication
   - name: antvis/mcp-server-chart
     github_id: antvis/mcp-server-chart
     description:


### PR DESCRIPTION
Adds **FrankKi** to `projects.yaml` under `communication`, per CONTRIBUTING.md (yaml only, never the README).

```yaml
- name: datPascal/frankki-mcp
  github_id: datPascal/frankki-mcp
  category: communication
```

**What it does.** An agent sends a real, printed letter or registered mail to a physical address anywhere in the world in one tool call: compose, price, send, track, with an explicit approval step before anything is posted. German compliance (Pflichtangaben, GoBD archive) built in.

- Repo: https://github.com/datPascal/frankki-mcp
- Homepage: https://frankki.app/en/mcp
- Connect URL: `https://mcp.frankki.app` (remote streamable-http, hosted, OAuth 2.1 with PKCE and DCR)
- Official MCP Registry: `app.frankki/letters@1.0.0`, published 2026-08-07
- 64 agent-callable tools: https://github.com/datPascal/frankki-mcp/blob/main/docs/tools.md

Checked first that it is not already in `projects.yaml`, the README, or the open issues. Category `communication` matches where the other physical-mail servers sit in the upstream taxonomy; there is no delivery or postal category on this list yet.

One note in case it affects your ranking: this repo carries the manifest and docs only. The server is hosted by us and is not self-hostable, so there is no source tree, no package, and star count will lag what the service does. Happy to drop the entry if that puts it outside the intent of the list.
