### PR TITLE
Add project: Autoposting-ai/autoposting-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2280,6 +2280,12 @@ projects:
       Browse Reddit posts, search content, and analyze user activity without API
       keys. Works out-of-the-box with Claude Desktop.
     category: social-media
+  - name: Autoposting-ai/autoposting-mcp
+    github_id: Autoposting-ai/autoposting-mcp
+    description: >-
+      Remote MCP server for Autoposting - schedule, generate and publish social
+      posts to X, LinkedIn, Instagram, Threads and YouTube from any MCP client.
+    category: social-media
   - name: r-huijts/strava-mcp
     github_id: r-huijts/strava-mcp
     description: >-


### PR DESCRIPTION
Adds Autoposting to `projects.yaml` under the `social-media` category (README untouched, per CONTRIBUTING).

- **What it does:** hosted MCP server for scheduling, generating and publishing social posts to X, LinkedIn, Instagram, Threads and YouTube — 69 tools covering posts, AI idea agents, brands, knowledge base, carousels, video clips and webhooks.
- **Endpoint:** `https://app.autoposting.ai/mcp`
- **Transport / auth:** Streamable HTTP with OAuth 2.1 Dynamic Client Registration — nothing to install, no client ID or secret to configure.
- **Docs:** https://docs.autoposting.ai/mcp/overview
- Published in the official MCP registry as `ai.autoposting/autoposting`.
