### PR TITLE
Add project: WP HealthKit

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2268,7 +2268,7 @@ projects:
       vetting.
     category: security
   - name: WP HealthKit
-    github_id: BuiltByGo/wp-healthkit
+    github_id: BuiltByGo/wphealthkit-mcp
     description: >-
       AI-powered security audits for WordPress plugins and themes via 58
       deterministic scanners plus AI engines. 13 tools: audit wp.org plugins or

--- a/projects.yaml
+++ b/projects.yaml
@@ -2267,6 +2267,17 @@ projects:
       and runs locally via Docker or as a standalone binary for fast, automated
       vetting.
     category: security
+  - name: WP HealthKit
+    github_id: BuiltByGo/wp-healthkit
+    description: >-
+      AI-powered security audits for WordPress plugins and themes via 58
+      deterministic scanners plus AI engines. 13 tools: audit wp.org plugins or
+      local ZIPs, retrieve graded reports and findings, fetch prioritised fix
+      plans and AI-ready fix prompts, generate SBOMs (CycloneDX/SPDX) and flag
+      false positives. npm stdio package (@wphealthkit/mcp-server) and hosted
+      remote MCP at mcp.wphealthkit.com/mcp. Listed on the official MCP
+      Registry as com.wphealthkit/mcp-server.
+    category: security
   - name: HagaiHen/facebook-mcp-server
     github_id: HagaiHen/facebook-mcp-server
     description: >-


### PR DESCRIPTION
Adds WP HealthKit to the `security` category.

- **Repo**: https://github.com/BuiltByGo/wp-healthkit (MCP server in packages/mcp-server, MIT)
- **npm**: `@wphealthkit/mcp-server` (stdio)
- **Remote**: https://mcp.wphealthkit.com/mcp (streamable HTTP, OAuth)
- **Official MCP Registry**: `com.wphealthkit/mcp-server`

AI-powered security audits for WordPress plugins and themes: 58 deterministic scanners + AI engines, graded reports, fix plans, SBOMs, false-positive feedback loop.