### PR TITLE
Add project: yantrikdb-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1848,6 +1848,14 @@ projects:
       (95.4%).
     pypi_id: omega-memory
     category: knowledge-and-memory
+  - name: yantrikos/yantrikdb-mcp
+    github_id: yantrikos/yantrikdb-mcp
+    pypi_id: yantrikdb-mcp
+    description: >-
+      Persistent cognitive memory for AI agents with semantic recall,
+      consolidation, contradiction detection, and temporal decay that survive
+      across sessions.
+    category: knowledge-and-memory
   - name: jagan-shanmugam/open-streetmap-mcp
     github_id: jagan-shanmugam/open-streetmap-mcp
     description:


### PR DESCRIPTION
Adds yantrikdb-mcp to the `knowledge-and-memory` category in projects.yaml, following the documented project properties (github_id + pypi_id).

Persistent cognitive memory for AI agents — semantic recall, consolidation, contradiction detection, temporal decay. Repo: https://github.com/yantrikos/yantrikdb-mcp

Disclosure: I'm the author. One project per PR as per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
