### PR TITLE
Add project: saga-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1480,6 +1480,13 @@ projects:
       persistent knowledge graph — average repo in milliseconds. 66 languages,
       sub-ms queries, 99% fewer tokens. Single static binary, zero dependencies.
     category: developer-tools
+  - name: spranab/saga-mcp
+    github_id: spranab/saga-mcp
+    description: >-
+      Jira-like project tracking (epics, stories, tasks) for AI agents that
+      lives inside the agent loop. SQLite-backed with 22 tools and a local
+      dashboard.
+    category: developer-tools
   - name: ChronulusAI/chronulus-mcp
     github_id: ChronulusAI/chronulus-mcp
     description:


### PR DESCRIPTION
Adds saga-mcp to the `developer-tools` category in projects.yaml, following the documented project properties.

Jira-like project tracking (epics/stories/tasks) for AI agents, inside the agent loop — SQLite-backed, 22 tools, local dashboard. Repo: https://github.com/spranab/saga-mcp

Disclosure: I'm the author. One project per PR as per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
