### PR TITLE
Add project: ZeroPointRepo/youtube-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2128,6 +2128,13 @@ projects:
       Vectorize MCP server for advanced retrieval, Private Deep Research,
       Anything-to-Markdown file extraction and text chunking.
     category: search-data-extraction
+  - name: ZeroPointRepo/youtube-mcp
+    github_id: ZeroPointRepo/youtube-mcp
+    description: >-
+      Remote MCP server for YouTube with six tools: transcripts, video and
+      channel search, channel browsing, in-channel search, playlist extraction,
+      and free RSS-based new-upload tracking.
+    category: search-data-extraction
   - name: zhsama/duckduckgo-mcp-server
     github_id: zhsama/duckduckgo-mcp-server
     description: >-


### PR DESCRIPTION
Adds one project entry to `projects.yaml` for [ZeroPointRepo/youtube-mcp](https://github.com/ZeroPointRepo/youtube-mcp).

**What it is:** a remote MCP server for YouTube. Six tools, all over one hosted HTTP endpoint so there is nothing to install locally: `get_youtube_transcript`, `search_youtube`, `get_channel_latest_videos`, `search_channel_videos`, `list_channel_videos`, `list_playlist_videos`. Auth is either a bearer API key or OAuth 2.1 with dynamic client registration, so clients that support DCR connect without a key being pasted into the conversation.

It differs from the YouTube transcript servers already on the list in that transcripts are one of six tools rather than the whole server, video, channel and playlist discovery are covered too, and upload tracking via RSS is free.

**Placement:** `search-data-extraction`, next to `lfnovo/content-core` and the other content-retrieval servers, inserted alphabetically before `zhsama/duckduckgo-mcp-server`. It is not a media *processing* server, so `multimedia-process` felt wrong.

**Checks I ran before opening this:**
- Searched `projects.yaml`, the README and the issue list. Neither the repo nor TranscriptAPI is listed or suggested.
- `projects.yaml` parses clean; all 406 `name` and `github_id` values remain unique.
- No line over 80 characters, so `.yamllint` stays green.
- One project per PR, title in the `Add project: <name>` format from CONTRIBUTING.

Repo is MIT licensed. Fair warning on the ranking: it is a young repo, so its project-quality score will start low and it will sort near the bottom of the category. Entirely your call whether that is worth a slot.

Disclosure: TranscriptAPI is an independent service from Zero Point Studio and is not affiliated with, endorsed by, or sponsored by YouTube or Google.
