### PR TITLE
Add project: runapi-ai/mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2520,6 +2520,12 @@ projects:
       talk to Asana API from MCP Client such as Anthropic's Claude Desktop
       Application, and many more.
     category: other-tools-and-integrations
+  - name: runapi-ai/mcp
+    github_id: runapi-ai/mcp
+    description: >-
+      MCP server for RunAPI model catalog and pricing lookup, prompt search, and
+      authenticated image, video, music, and text-to-speech task creation.
+    category: other-tools-and-integrations
   - name: SecretiveShell/MCP-wolfram-alpha
     github_id: SecretiveShell/MCP-wolfram-alpha
     description: An MCP server for querying wolfram alpha API.


### PR DESCRIPTION
Adds one project entry to `projects.yaml` for [runapi-ai/mcp](https://github.com/runapi-ai/mcp).

It is an MCP server for RunAPI model catalog and pricing lookup, prompt search, and authenticated image, video, music, and text-to-speech task creation. I placed it under `other-tools-and-integrations`, matching nearby media/API MCP entries such as `apinetwork/piapi-mcp-server`.

Checks run before opening:
- Searched `projects.yaml`, README, issues, and PRs for an existing RunAPI entry.
- Parsed `projects.yaml`; all `name` and `github_id` values remain unique.
- `git diff --check` passed.

I did not edit the generated README.