### PR TITLE
Add project: bytebase/dbhub

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -792,6 +792,14 @@ projects:
       MySQL database integration in NodeJS with configurable access controls and
       schema inspection
     category: databases
+  - name: bytebase/dbhub
+    github_id: bytebase/dbhub
+    npm_id: "@bytebase/dbhub"
+    description: >-
+      Zero-dependency, token-efficient universal database MCP server for
+      PostgreSQL, MySQL, SQL Server, MariaDB, and SQLite — one connection
+      string, stdio and HTTP transports.
+    category: databases
   - name: baserow/baserow
     github_id: baserow/baserow
     description: >-


### PR DESCRIPTION
Adds [DBHub](https://github.com/bytebase/dbhub) to the `databases` category.

DBHub is a standalone, zero-dependency universal database MCP server (npm [`@bytebase/dbhub`](https://www.npmjs.com/package/@bytebase/dbhub)): one connection string, stdio and HTTP transports, supporting PostgreSQL, MySQL, SQL Server, MariaDB, and SQLite. It is also published in the official MCP registry as `io.github.bytebase/dbhub`.

Checked projects.yaml, the README, and open issues — not previously added or suggested.