### PR TITLE
Add project: bytebase/bytebase

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -800,11 +800,11 @@ projects:
     category: databases
   - name: bytebase/bytebase
     github_id: bytebase/bytebase
-    homepage: https://docs.bytebase.com/integrations/mcp
     description: >-
-      MCP server built into the Bytebase database governance platform — AI
-      assistants connect to a running Bytebase instance over HTTP with OAuth,
-      and queries inherit its access control, data masking, and audit logging.
+      Governed multi-database MCP server backed by the Bytebase platform —
+      query, schema change, and permission management across 30+ database
+      engines, with access control, data masking, SQL review, and audit
+      logging enforced at the MCP boundary.
     category: databases
   - name: Canner/wren-engine
     github_id: Canner/wren-engine

--- a/projects.yaml
+++ b/projects.yaml
@@ -798,6 +798,14 @@ projects:
       Baserow database integration with table search, list, and row create,
       read, update, and delete capabilities.
     category: databases
+  - name: bytebase/bytebase
+    github_id: bytebase/bytebase
+    homepage: https://docs.bytebase.com/integrations/mcp
+    description: >-
+      MCP server built into the Bytebase database governance platform — AI
+      assistants connect to a running Bytebase instance over HTTP with OAuth,
+      and queries inherit its access control, data masking, and audit logging.
+    category: databases
   - name: Canner/wren-engine
     github_id: Canner/wren-engine
     description:


### PR DESCRIPTION
Adds [Bytebase](https://github.com/bytebase/bytebase) to the `databases` category, for its built-in MCP server.

To be transparent about what this entry is: unlike a standalone server, the Bytebase MCP server is served by a running Bytebase instance (an open-source database governance platform) at `https://<instance>/mcp` — a remote/HTTP MCP server with OAuth. AI assistants that connect inherit the instance's access control, data masking, and audit logging. Docs: https://docs.bytebase.com/integrations/mcp. The list already carries platform repos whose MCP capability is built in (e.g. `baserow/baserow`), which is why I filed it this way rather than pointing at a nonexistent separate repo. Happy to adjust the framing if you'd prefer it categorized differently.

(The standalone DBHub server from the same team is proposed separately in its own PR, per the one-project-per-PR guideline.)

Checked projects.yaml, the README, and open issues — not previously added or suggested.