### PR TITLE
Add project: slacking-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1679,6 +1679,16 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: Th3Slack3r/slacking-mcp
+    github_id: Th3Slack3r/slacking-mcp
+    description: >-
+      67 MCP tools for US financial and economic data: SEC EDGAR company
+      financials (10-K/10-Q/8-K, insider trades, sentiment), FRED macro
+      economics, Census demographics, IRS 990 nonprofit filings, FDA health
+      data, and official US Debt & Treasury. Remote Streamable HTTP server with
+      public discovery; per-request API key for data calls.
+    category: finance-and-fintech
+
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:

--- a/projects.yaml
+++ b/projects.yaml
@@ -1686,7 +1686,8 @@ projects:
       financials (10-K/10-Q/8-K, insider trades, sentiment), FRED macro
       economics, Census demographics, IRS 990 nonprofit filings, FDA health
       data, official US Debt & Treasury, and UK Companies House KYB. Remote
-      Streamable HTTP server with public discovery; per-request API key for data calls.
+      Streamable HTTP server with public discovery; per-request API key for
+      data calls.
     category: finance-and-fintech
 
   - name: CoderGamester/mcp-unity

--- a/projects.yaml
+++ b/projects.yaml
@@ -1682,11 +1682,11 @@ projects:
   - name: Th3Slack3r/slacking-mcp
     github_id: Th3Slack3r/slacking-mcp
     description: >-
-      67 MCP tools for US financial and economic data: SEC EDGAR company
+      75 MCP tools for US financial and economic data: SEC EDGAR company
       financials (10-K/10-Q/8-K, insider trades, sentiment), FRED macro
       economics, Census demographics, IRS 990 nonprofit filings, FDA health
-      data, and official US Debt & Treasury. Remote Streamable HTTP server with
-      public discovery; per-request API key for data calls.
+      data, official US Debt & Treasury, and UK Companies House KYB. Remote
+      Streamable HTTP server with public discovery; per-request API key for data calls.
     category: finance-and-fintech
 
   - name: CoderGamester/mcp-unity


### PR DESCRIPTION
Adds **slacking-mcp** to `projects.yaml` under `finance-and-fintech`.

- Repo: https://github.com/Th3Slack3r/slacking-mcp
- Hosted MCP server: https://slacking.biz/mcp (Streamable HTTP) — also on the Official MCP Registry as `io.github.Th3Slack3r/slacking-biz` (v1.2.1, 75 tools)
- 75 MCP tools: SEC EDGAR company financials (10-K/10-Q/8-K, insider trades, sentiment), FRED macro economics, Census demographics, IRS 990 nonprofit filings, FDA health data, US Debt & Treasury, UK Companies House company & KYB data. Public discovery (initialize + tools/list); per-request API key for data calls.

Single entry added; YAML validated. Thanks