### PR TITLE
Add Compartment to knowledge-and-memory

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1848,6 +1848,13 @@ projects:
       (95.4%).
     pypi_id: omega-memory
     category: knowledge-and-memory
+  - name: MaxFreedomPollard/Compartment
+    github_id: MaxFreedomPollard/Compartment
+    description: >-
+      Fully offline, encrypted vector memory for AI agents. AEAD-encrypts
+      everything at rest including embedding vectors, with cryptographic
+      deletion and no network access.
+    category: knowledge-and-memory
   - name: jagan-shanmugam/open-streetmap-mcp
     github_id: jagan-shanmugam/open-streetmap-mcp
     description:


### PR DESCRIPTION
Adds Compartment to the `knowledge-and-memory` category.

Repo: https://github.com/MaxFreedomPollard/Compartment
License: Apache-2.0
Published in the official MCP registry as `io.github.MaxFreedomPollard/compartment`

Compartment is an MCP server providing durable vector memory for AI agents that never leaves the machine. It runs with no network at all (no API key, no cloud account) and AEAD-encrypts everything at rest, embedding vectors included. Memories are created, stored and recalled without an external LLM.
