### PR TITLE
Add project: etincel

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1480,6 +1480,14 @@ projects:
       persistent knowledge graph — average repo in milliseconds. 66 languages,
       sub-ms queries, 99% fewer tokens. Single static binary, zero dependencies.
     category: developer-tools
+  - name: AIStoryHub/etincel
+    github_id: AIStoryHub/etincel
+    description: >-
+      Deterministic, local audit for AI writing tells, paired with a trainable
+      voice layer so Claude, Cursor, or any MCP client drafts closer to a real
+      voice. No model call in the audit path. Also ships as a CLI and GitHub
+      Action.
+    category: developer-tools
   - name: ChronulusAI/chronulus-mcp
     github_id: ChronulusAI/chronulus-mcp
     description:


### PR DESCRIPTION
Adds [AIStoryHub/etincel](https://github.com/AIStoryHub/etincel) to `projects.yaml` under `developer-tools`: a deterministic, local audit for AI writing tells (no model call in the audit path), paired with a trainable voice layer for Claude, Cursor, and any MCP client. MIT licensed.

- [x] Added to `projects.yaml` only, not `README.md`
- [x] One project, one PR
- [x] Title matches the required `Add project: project-name` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U24Csv17sJtoAqZtS1eNLU