### PR TITLE
Add project: agent-qa

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -369,6 +369,14 @@ projects:
       navigate pages, fill forms, extract data, handle authentication, and
       automate any website via natural language
     category: browser-automation
+  - name: vostride/agent-qa
+    github_id: vostride/agent-qa
+    npm_id: agent-qa
+    description: >-
+      A source-available, self-improving QA agent for natural-language web and
+      mobile tests. Its MCP server lets coding agents author tests and enqueue
+      runs, inspect evidence, and triage failures with persistent test memory.
+    category: browser-automation
   - name: alexei-led/aws-mcp-server
     github_id: alexei-led/aws-mcp-server
     description: >-


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Add `vostride/agent-qa` to Browser Automation. Agent QA is a source-available, self-improving QA agent for natural-language web/mobile tests. Its MCP surface lets coding agents author tests, enqueue runs, inspect logs and artifacts, cancel work, and triage failures while persistent test memory improves later runs.

The record includes the published npm package ID, `agent-qa`. The current license is FSL-1.1-ALv2, converting to Apache-2.0 after two years.

Verification:

- The repository's exact `.yamllint` configuration passes on `projects.yaml`.
- The YAML parses successfully and contains exactly one project with `github_id: vostride/agent-qa`.
- Project names remain unique, every added line stays within the configured 80-character limit, and `git diff --check` passes.

Disclosure: I am affiliated with Agent QA and Vostride.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
