### PR TITLE
Add plumbkit/plumb to developer-tools

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1480,6 +1480,15 @@ projects:
       persistent knowledge graph — average repo in milliseconds. 66 languages,
       sub-ms queries, 99% fewer tokens. Single static binary, zero dependencies.
     category: developer-tools
+  - name: plumbkit/plumb
+    github_id: plumbkit/plumb
+    description: >-
+      IDE intelligence for coding agents, with guardrails for unattended work.
+      LSP-backed navigation and refactoring, a tree-sitter topology index for
+      structure and blast radius, and per-project memory — plus atomic
+      crash-durable writes, a workspace path boundary and tiered git gating.
+      One shared daemon behind a reconnecting proxy. Single Go binary.
+    category: developer-tools
   - name: ChronulusAI/chronulus-mcp
     github_id: ChronulusAI/chronulus-mcp
     description:


### PR DESCRIPTION
Adds [plumb](https://github.com/plumbkit/plumb) to `projects.yaml` under `developer-tools`, per CONTRIBUTING.md (added to the yaml, never to the README).

plumb gives a coding agent IDE-grade intelligence over MCP — LSP-backed navigation and refactoring (definitions, references, rename, call/type hierarchy, diagnostics), a tree-sitter topology index for structure, blast radius and which tests a change affects, and per-project memory — with the safety envelope unattended agents need: atomic crash-durable writes, a workspace path boundary, and tiered git gating.

- Apache-2.0, single Go binary, macOS + Linux
- Published on the official MCP registry as `io.github.plumbkit/plumb` (currently 0.16.6)

Checked before opening: searched `projects.yaml`, the README and the issue list — no existing plumb entry. `projects.yaml` re-parsed after the edit and the new entry resolves to `category: developer-tools`.