### PR TITLE
Add hanicker/proofite-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2352,6 +2352,15 @@ projects:
       Azure DevOps integration for repository management, work items, and
       pipelines.
     category: version-control
+  - name: hanicker/proofite-mcp
+    github_id: hanicker/proofite-mcp
+    npm_id: proofite-mcp
+    homepage: https://proofite.com/mcp
+    description: >-
+      Read your AI-written daily news briefing and retune the filter behind it:
+      RSS feeds, newsletters, monitored web searches, topic preferences,
+      read-later queue and podcast. Remote Streamable HTTP server, also on npm.
+    category: workplace-and-productivity
   - name: MarkusPfundstein/mcp-gsuite
     github_id: MarkusPfundstein/mcp-gsuite
     description: Integration with gmail and Google Calendar.


### PR DESCRIPTION
Adds [proofite-mcp](https://github.com/hanicker/proofite-mcp) to `projects.yaml` under **workplace-and-productivity**. README untouched (it is regenerated by the weekly workflow).

**What it does:** Proofite turns the sources you choose — newsletters, RSS feeds, monitored web searches, saved links — into one AI-written daily briefing, also available as a podcast. The MCP server lets an agent read that briefing and retune the filter behind it: topics, depth, technicality, schedule, sources. 27 tools, plus resources and prompts.

- Remote Streamable HTTP endpoint: https://proofite.com/mcp (Bearer API key, can be created read-only)
- npm package: [`proofite-mcp`](https://www.npmjs.com/package/proofite-mcp)
- Published in the official MCP Registry as `com.proofite/proofite`
- Docs: https://proofite.com/mcp · MIT