### PR TITLE
Add project: brainstorm-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -118,6 +118,14 @@ categories:
     subtitle: MCP servers for other tools and integrations
 
 projects:
+  - name: spranab/brainstorm-mcp
+    github_id: spranab/brainstorm-mcp
+    npm_id: brainstorm-mcp
+    description: >-
+      Runs multi-round debates between several models (GPT, Gemini, DeepSeek,
+      Claude, local Ollama), then returns a structured synthesis with the
+      recommendation, tradeoffs and the strongest disagreement.
+    category: developer-tools
   - name: cocoindex-io/cocoindex-code
     github_id: cocoindex-io/cocoindex-code
     description: >-


### PR DESCRIPTION
Adds `spranab/brainstorm-mcp` to `projects.yaml` under `developer-tools`.

**What it does.** An MCP server that runs a multi-round debate between several models — OpenAI, Gemini, DeepSeek, Claude, and local Ollama — and returns a structured synthesis: recommendation, key tradeoffs, and the strongest disagreement between the models. It also has a quick mode and a multi-model code-review mode. Hosted mode uses whatever models the calling agent already has, so it works without API keys.

**Against the current inclusion threshold** (public, non-archived, updated within 180 days, 50+ stars) that you cited when closing #349 and #350: this repo is public and not archived, was last pushed today, and has 67 stars. MIT, published on npm as `brainstorm-mcp`, listed in the official MCP registry.

I also maintain `truenas-mcp`, which is at 6 stars — under the threshold, so I have not submitted it.

One project per PR and the `Add project: <name>` title format, per CONTRIBUTING.md. Disclosure: I'm the author.