### PR TITLE
Add project: vantage-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1905,6 +1905,12 @@ projects:
       This server supports remote MCP connections, includes built-in Google
       OAuth, and provide an interface to the Google Tag Manager API.
     category: marketing
+  - name: vantagemcp/vantage-mcp
+    github_id: vantagemcp/vantage-mcp
+    description: >-
+      Checks whether ChatGPT, Perplexity, and Gemini cite your brand for a
+      given keyword, and who's winning the citation battle for it instead.
+    category: marketing
   - name: grafana/mcp-grafana
     github_id: grafana/mcp-grafana
     description: >-


### PR DESCRIPTION
Adds vantage-mcp (vantagemcp/vantage-mcp) under the `marketing` category.

Checks whether ChatGPT, Perplexity, and Gemini cite a brand for a given keyword, and who's winning the citation battle for it instead. Callable directly from Claude Code, Cursor, or any MCP client.

Published on the Official MCP Registry under the domain-verified namespace `dev.vantagemcp/vantage`.