### PR TITLE
Add project: Pocket Drives

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2340,6 +2340,12 @@ projects:
     github_id: openbnb-org/mcp-server-airbnb
     description: Provides tools to search Airbnb and get listing details.
     category: travel-and-transportation
+  - name: RevList/pocket-drives-mcp
+    github_id: RevList/pocket-drives-mcp
+    description: >-
+      Peer-to-peer luxury, exotic, and EV rental search from independent hosts.
+      Read-only search, quotes, and availability. Booking finishes in the iOS app.
+    category: travel-and-transportation
   - name: github/github-mcp-server
     github_id: github/github-mcp-server
     description: >-


### PR DESCRIPTION
Adds Pocket Drives to Travel & Transportation in `projects.yaml` only (README is generated).

- Listing repo: https://github.com/RevList/pocket-drives-mcp
- Remote Streamable HTTP (no auth): https://pocketdrives.ai/mcp
- Official registry: `ai.pocketdrives/pocket-drives`

Pocket Drives is a P2P luxury/exotic/EV rental marketplace. Independent hosts; PocketList Inc builds the platform. This server searches, quotes, and browses. Booking finishes in the iOS app.

Single new `projects.yaml` entry after Airbnb. Title format per CONTRIBUTING.