### PR TITLE
Add offendersearch/mcp (search-data-extraction)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -118,6 +118,13 @@ categories:
     subtitle: MCP servers for other tools and integrations
 
 projects:
+  - name: offendersearch/mcp
+    github_id: offendersearch/mcp
+    description: >-
+      Searches all 58 US sex-offender registries — every US state, DC and the
+      territories — in one query by name, DOB, city/ZIP, address or GIS radius.
+      Backed by offendersearch.app.
+    category: search-data-extraction
   - name: cocoindex-io/cocoindex-code
     github_id: cocoindex-io/cocoindex-code
     description: >-


### PR DESCRIPTION
Adds offendersearch/mcp under search-data-extraction. Searches all 58 US sex-offender registries — every US state, DC and the territories — in one query by name, DOB, city/ZIP, address or GIS radius. Backed by offendersearch.app. Repo: https://github.com/offendersearch/mcp
