### PR TITLE
Add cmhenry79/merlonix-mcp (monitoring)

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2588,3 +2588,12 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: cmhenry79/merlonix-mcp
+    github_id: cmhenry79/merlonix-mcp
+    description: >-
+      Live website and infrastructure monitoring MCP server (16 tools):
+      SSL/TLS, DNS and domain-registration health for any hostname, MCP-server
+      health plus an A-F security grade, AI agent-readiness scoring, email
+      blacklist and broken-link checks, and live status for 11 major cloud
+      vendors. Hosted over Streamable HTTP; public tools need no auth.
+    category: monitoring


### PR DESCRIPTION
Adds **Merlonix** to `projects.yaml` under the `monitoring` category.

- **Repo:** https://github.com/cmhenry79/merlonix-mcp (MIT)
- Live website/infrastructure-monitoring MCP server, **16 tools** (8 public/no-auth + 8 account): SSL/TLS + DNS + domain-registration health, MCP-server health + A–F security grade, AI agent-readiness, email blacklist, broken-link scan, live status for 11 cloud vendors.
- Hosted over Streamable HTTP (`https://api.merlonix.com/mcp`) or `npx -y github:cmhenry79/merlonix-mcp`; also in the official modelcontextprotocol registry as `com.merlonix/monitoring`.

YAML validated (`yaml.safe_load` parses; entry lands in `projects`).