### PR TITLE
Add project: trace-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2588,3 +2588,10 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: nikolai-vysotskyi/trace-mcp
+    github_id: nikolai-vysotskyi/trace-mcp
+    description: >-
+      Precomputed code-intelligence graph for AI agents — symbol search, call
+      graphs, change impact, and test mapping as structured MCP tools instead
+      of whole-file reads.
+    category: developer-tools


### PR DESCRIPTION
Adds trace-mcp to the Developer Tools category.

[trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp) is a precomputed code-intelligence graph served over MCP. It provides symbol search, call graphs, change impact analysis, and test mapping as structured MCP tools instead of whole-file reads.

- Searched first — trace-mcp was not already listed
- I maintain the project