### PR TITLE
Add project: MCP Emails

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2588,3 +2588,10 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: Albretsen/MCPEmails
+    github_id: Albretsen/MCPEmails
+    description: >-
+      Hosted email MCP server for Gmail, Fastmail, iCloud, Yahoo, Zoho, Yandex
+      and any IMAP/SMTP mailbox. Read, search, send, organize, draft and
+      schedule mail from any MCP client over Streamable HTTP.
+    category: communication


### PR DESCRIPTION
Adds MCP Emails to `projects.yaml` under the `communication` category.

Hosted MCP server that connects Gmail, Fastmail, iCloud, Yahoo, Zoho, Yandex and any IMAP/SMTP mailbox to Claude, Cursor and other MCP clients over Streamable HTTP.

- Repo: https://github.com/Albretsen/MCPEmails (AGPL-3.0)
- Docs: https://mcpemails.com/docs

Per CONTRIBUTING: added to `projects.yaml` only, not to README.md, using the documented `name` / `github_id` / `description` / `category` properties, and titled `Add project: project-name`.

I am the maintainer.