### PR TITLE
Add project: azeemkafridi/bulkpublish-api

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2280,6 +2280,12 @@ projects:
       comments, and engagement metrics through the Graph API for streamlined
       social media management.
     category: social-media
+  - name: azeemkafridi/bulkpublish-api
+    github_id: azeemkafridi/bulkpublish-api
+    description: >-
+      MCP server and API for AI agents to plan, review, schedule, publish, and
+      analyze social media content across connected channels through BulkPublish.
+    category: social-media
   - name: karanb192/reddit-mcp-buddy
     github_id: karanb192/reddit-mcp-buddy
     description: >-

--- a/projects.yaml
+++ b/projects.yaml
@@ -2284,7 +2284,8 @@ projects:
     github_id: azeemkafridi/bulkpublish-api
     description: >-
       MCP server and API for AI agents to plan, review, schedule, publish, and
-      analyze social media content across connected channels through BulkPublish.
+      analyze social media content across connected channels through
+      BulkPublish.
     category: social-media
   - name: karanb192/reddit-mcp-buddy
     github_id: karanb192/reddit-mcp-buddy


### PR DESCRIPTION
Adds the official BulkPublish MCP server and API to the Social Media category.

Repository: https://github.com/azeemkafridi/bulkpublish-api
MCP docs: https://app.bulkpublish.com/docs
Skills: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills

This is a self-submission.