### PR TITLE
Add Edgrapi (US government data MCP server) to data-platforms

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1685,6 +1685,10 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: paperandbeyond23-gif/edgrapi-skills
+    github_id: paperandbeyond23-gif/edgrapi-skills
+    description: SEC EDGAR filings as clean JSON - Form 4 insider trades with cluster-buy detection, 8-K events, 13F holdings diffed quarter-over-quarter, 13D/13G >5% stakes, XBRL fundamentals and full-text search.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:

--- a/projects.yaml
+++ b/projects.yaml
@@ -1687,7 +1687,10 @@ projects:
     category: finance-and-fintech
   - name: paperandbeyond23-gif/edgrapi-skills
     github_id: paperandbeyond23-gif/edgrapi-skills
-    description: SEC EDGAR filings as clean JSON - Form 4 insider trades with cluster-buy detection, 8-K events, 13F holdings diffed quarter-over-quarter, 13D/13G >5% stakes, XBRL fundamentals and full-text search.
+    description: >-
+      SEC EDGAR filings as clean JSON - Form 4 insider trades with cluster-buy
+      detection, 8-K events, 13F holdings diffed quarter-over-quarter, 13D/13G
+      stakes above 5 percent, XBRL fundamentals and full-text search.
     category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Adds **Edgrapi** (`paperandbeyond23-gif/edgrapi-skills`) to `data-platforms`.

A remote MCP server for US government data as clean JSON: SAM.gov contract opportunities, USAspending awards, Grants.gov grants, House STOCK Act congressional trades, and SEC EDGAR filings (insider trades, 8-K events, 13F holdings, 13D/G stakes, XBRL fundamentals). 19 read-only tools, OAuth sign-in for MCP clients, streamable-http at `https://api.edgrapi.com/mcp`. Free tier, no card. Listed on the official MCP registry.

_Updated 2026-09-17: Edgrapi expanded from SEC-only to US government data, so the entry moved from `finance-and-fintech` to `data-platforms`._

One project added, nothing else changed. Field order and indentation match the neighbouring entries, and the edited `projects.yaml` parses as valid YAML (407 projects).

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
