### PR TITLE
Add project: AetherAI3/agent-browser

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2588,3 +2588,12 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: AetherAI3/agent-browser
+    github_id: AetherAI3/agent-browser
+    description: >-
+      Self-hosted Chrome for AI agents. One browser session driven over MCP,
+      with a live noVNC view where a human can watch and take over at logins
+      or 2FA
+    npm_id: aether-browser
+    pypi_id: aether-browser
+    category: browser-automation


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project
- [ ] Update a project
- [ ] Remove a project
- [ ] Add or update a category
- [ ] Change configuration
- [ ] Documentation
- [ ] Other, please describe:

**Description:**

Adds **AetherAI3/agent-browser** to `projects.yaml` under `browser-automation`. One project, one file, nine lines.

Agent Browser is a self-hosted headed Chrome session for AI agents. Both clients (npm and PyPI, `aether-browser`) serve the same nine-tool MCP server over stdio via `aether-browser mcp`, and the session is mirrored through a local noVNC view so a human can watch and take over at logins or 2FA, then hand control back to the agent.

- Repository: https://github.com/AetherAI3/agent-browser (Apache-2.0)
- MCP docs: https://github.com/AetherAI3/agent-browser/blob/main/docs/MCP.md
- Packages: [`aether-browser` on npm](https://www.npmjs.com/package/aether-browser), [`aether-browser` on PyPI](https://pypi.org/project/aether-browser/)

Both `npm_id` and `pypi_id` are set so the generator picks up download stats for the two clients.

Checked `projects.yaml`, the README, and the issue list for duplicates — not present. `yamllint projects.yaml` passes with the repo's `.yamllint` config. Disclosure: I'm the project's author and maintainer.

**Checklist:**

- [x] I have read the [CONTRIBUTING](https://github.com/best-of-lists/best-of/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have not modified the `README.md` file. Projects are only supposed to be added or updated within the `projects.yaml` file since the `README.md` file is automatically generated.
