### PR TITLE
Add project: chico10117/basepay-readiness-service

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1685,6 +1685,12 @@ projects:
       tools for HTTP 402-based USDC payments on Base, Arbitrum, and other EVM
       chains.
     category: finance-and-fintech
+  - name: chico10117/basepay-readiness-service
+    github_id: chico10117/basepay-readiness-service
+    description: >-
+      MCP service for inspecting x402 endpoint challenges before USDC payment
+      on Base; it never connects a buyer wallet, signs, or spends.
+    category: finance-and-fintech
   - name: CoderGamester/mcp-unity
     github_id: CoderGamester/mcp-unity
     description:


### PR DESCRIPTION
## Summary

Add `chico10117/basepay-readiness-service` to Finance & Fintech.

x402 Preflight is a hosted MCP service for inspecting x402 payment challenges before agents spend USDC on Base. Its free inspection path does not connect a buyer wallet, sign, or spend.

## Validation

- confirmed no matching project in `projects.yaml`, README, open PRs, or issues
- canonical production endpoint: https://x402.chikocorp.com
- official MCP Registry descriptor `io.github.chico10117/x402-preflight` is active at version 1.0.1
- `yamllint projects.yaml` passes
- parsed YAML contains exactly one matching `github_id` in `finance-and-fintech`
- `git diff --check` passes
