### PR TITLE
Add project: alexandria-mcp

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2588,3 +2588,11 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: The-40-Thieves/alexandria-mcp
+    github_id: The-40-Thieves/alexandria-mcp
+    npm_id: "@the-40-thieves/alexandria-mcp"
+    description: >-
+      Natural-language search, full-text reading, and cited answers across 152
+      public research libraries: papers, books, law, government records,
+      security advisories, news, and developer docs.
+    category: search-data-extraction


### PR DESCRIPTION
Adds The-40-Thieves/alexandria-mcp to projects.yaml under search-data-extraction. Alexandria is an MIT licensed, TypeScript MCP server that gives agents natural language search, full text reading, and cited answers across 152 public research libraries: papers, books, law, government records, security advisories, news, and developer docs. Published on npm as @the-40-thieves/alexandria-mcp, starts over stdio with npx -y @the-40-thieves/alexandria-mcp. Repo: https://github.com/The-40-Thieves/alexandria-mcp


🤖 Generated with [Claude Code](https://claude.com/claude-code)
