### PR TITLE
Add project: ContextStream

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -1757,6 +1757,14 @@ projects:
       RAG chunks, files, and conversation history before they reach the LLM,
       with reversible retrieval through MCP tools.
     category: knowledge-and-memory
+  - name: ContextStream
+    github_id: contextstream/mcp-server
+    npm_id: "@contextstream/mcp-server"
+    homepage: https://contextstream.io
+    description: >-
+      Shared project memory and semantic code search for AI coding agents
+      (Cursor, Claude Code, Codex, Grok). Hosted MCP with OAuth or local stdio.
+    category: knowledge-and-memory
   - name: entanglr/zettelkasten-mcp
     github_id: entanglr/zettelkasten-mcp
     description: >-


### PR DESCRIPTION
Adds ContextStream to projects.yaml under knowledge-and-memory.

- GitHub: https://github.com/contextstream/mcp-server
- npm: @contextstream/mcp-server
- Homepage: https://contextstream.io
- Hosted MCP: https://mcp.contextstream.io/mcp

Closes #392