### PR TITLE
Add project: ParlayAPI

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2290,9 +2290,10 @@ projects:
     github_id: JacobiusMakes/parlay-api-mcp
     pypi_id: parlayapi-mcp
     description: >-
-      Sports odds tools for personal and internal research, with keyless discovery
-      and authenticated access using your own account. Also exposes account
-      signup, login-email, checkout-link and saved-book-preference tools.
+      Sports odds tools for personal and internal research, with keyless
+      discovery and authenticated access using your own account. Also exposes
+      account signup, login-email, checkout-link and saved-book-preference
+      tools.
     category: sports
   - name: r-huijts/strava-mcp
     github_id: r-huijts/strava-mcp

--- a/projects.yaml
+++ b/projects.yaml
@@ -2286,6 +2286,14 @@ projects:
       Browse Reddit posts, search content, and analyze user activity without API
       keys. Works out-of-the-box with Claude Desktop.
     category: social-media
+  - name: ParlayAPI
+    github_id: JacobiusMakes/parlay-api-mcp
+    pypi_id: parlayapi-mcp
+    description: >-
+      Sports odds tools for personal and internal research, with keyless discovery
+      and authenticated access using your own account. Also exposes account
+      signup, login-email, checkout-link and saved-book-preference tools.
+    category: sports
   - name: r-huijts/strava-mcp
     github_id: r-huijts/strava-mcp
     description: >-


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Add a project

**Description:**

Adds ParlayAPI to the existing Sports category, with its GitHub repository and PyPI package. It provides sports-odds tools for personal/internal research and keyless discovery. The entry also discloses its account-signup, login-email, checkout-link and saved-book-preference tools.

Owner-submitted and AI-assisted. No native-client compatibility, coverage total or profitability claim is added.

**Checklist:**

- [x] I have read the CONTRIBUTING guidelines, including the linked best-of template guidelines.
- [x] I have not modified `README.md`; only `projects.yaml` changes.
- [x] Searched the projects, README and existing issues/PRs for duplicates.

Validation: parsed the complete YAML, verified one unique project was added to a valid category, and confirmed all existing parsed data is unchanged. `git diff --check` passes.
