### PR TITLE
Add projects: obsidian-tc, codecalc

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -2588,3 +2588,23 @@ projects:
     description: >-
       MCP server that exercises all the features of the MCP protocol.
     category: other-tools-and-integrations
+  - name: The-40-Thieves/obsidian-tc
+    github_id: The-40-Thieves/obsidian-tc
+    npm_id: obsidian-tc
+    description: >-
+      Governed, agent-ready MCP server for Obsidian vaults. Three
+      meta-tools expose roughly 163 governed capabilities across 31
+      domains (notes, links, search, metadata, git, knowledge graph)
+      behind folder ACLs and human-in-the-loop confirmation, with
+      fused BM25, vector, and graph retrieval. Multi-vault native,
+      pluggable embeddings.
+    category: knowledge-and-memory
+  - name: The-40-Thieves/codecalc
+    github_id: The-40-Thieves/codecalc
+    pypi_id: codecalc
+    description: >-
+      Universal code and logic calculator for AI models: 52 MCP tools
+      across 31 languages. Rust-sandboxed execution with verdicts,
+      sessions, artifacts, exact arithmetic, and verified
+      translation/optimization.
+    category: code-execution


### PR DESCRIPTION
Adds two MCP servers from The 40 Thieves to `projects.yaml`:

- **The-40-Thieves/obsidian-tc** under `knowledge-and-memory` — an AGPL-3.0-only, TypeScript+Rust governed MCP server for Obsidian vaults. Three meta-tools (`find_capability`, `describe_capability`, `call_capability`) expose ~163 governed capabilities across 31 domains (notes, links, search, metadata, git, knowledge graph) behind folder ACLs and human-in-the-loop confirmation, with fused BM25 + vector + graph retrieval. Published on npm as `obsidian-tc`. Repo: https://github.com/The-40-Thieves/obsidian-tc
- **The-40-Thieves/codecalc** under `code-execution` — an Apache-2.0 universal code/logic calculator for AI models: 52 MCP tools across 31 languages, Rust-sandboxed execution with verdicts, sessions, artifacts, exact arithmetic, and verified translation/optimization. Published on PyPI as `codecalc` and on crates.io as `codecalc-exec` (this schema's documented `Supported Package Managers` — `pypi_id`, `conda_id`, `npm_id`, `dockerhub_id`, `maven_id` — has no crates.io/cargo property, so only `pypi_id` is set; the crates.io publish is mentioned here for completeness). Repo: https://github.com/The-40-Thieves/codecalc

## Note on combining these into one PR

CONTRIBUTING.md asks for "an individual issue or pull request for each project," which this PR doesn't follow — it was combined into one at the requester's explicit instruction, since both projects ship from the same org and were being submitted in the same pass. Happy to split this into two PRs if a maintainer would rather review them that way.

## Validation

This repo's README/CONTRIBUTING don't document a local `projects.yaml` validation command (checks run via the best-of-generator GitHub Action in CI). I validated locally with:

```
python3 -c "
import yaml
with open('projects.yaml') as f:
    data = yaml.safe_load(f)
names = [p['name'] for p in data['projects']]
assert len(names) == len(set(names))
cats = {c['category'] for c in data['categories']}
assert 'knowledge-and-memory' in cats and 'code-execution' in cats
"
```

which confirms the file still parses as valid YAML, both new project names are unique, and both categories exist in this file's own category list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A52DVwwKYFY95cqxErKu9j
