### PR TITLE
Add zopdev/mcp to cloud-platforms

### DIFF
--- a/projects.yaml
+++ b/projects.yaml
@@ -520,9 +520,10 @@ projects:
     github_id: zopdev/mcp
     homepage: https://zop.dev/learn/mcp-server?utm_source=tolkonepiu-best-of-mcp-servers&utm_medium=listing&utm_campaign=mcp-directory
     description: >-
-      Cloud cost, inventory and governance across AWS, Azure and GCP. 289 tools
-      (165 read, 124 write), read-only by default with optional scoped writes,
-      over a hosted remote streamable-HTTP endpoint.
+      Cloud cost and infrastructure governance across AWS, Azure, GCP,
+      Databricks and Snowflake. 289 tools (165 read, 124 write), read-only by
+      default with optional scoped writes, over a hosted remote
+      streamable-HTTP endpoint.
     category: cloud-platforms
   - name: alfonsograziano/node-code-sandbox-mcp
     github_id: alfonsograziano/node-code-sandbox-mcp

--- a/projects.yaml
+++ b/projects.yaml
@@ -521,9 +521,10 @@ projects:
     homepage: https://zop.dev/learn/mcp-server?utm_source=tolkonepiu-best-of-mcp-servers&utm_medium=listing&utm_campaign=mcp-directory
     description: >-
       Cloud cost and infrastructure governance across AWS, Azure, GCP,
-      Databricks and Snowflake. 263 tools (155 read, 108 write), read-only by
-      default with optional scoped writes, over a hosted remote
-      streamable-HTTP endpoint.
+      Databricks and Snowflake. 263 tools (155 read, 108 write) covering cost,
+      resources, schedules, recommendations, budgets, governance and
+      diagnostics. Read-only by default, with optional scoped writes. Hosted
+      remote streamable-HTTP endpoint at https://api.zop.dev/mcp-server.
     category: cloud-platforms
   - name: alfonsograziano/node-code-sandbox-mcp
     github_id: alfonsograziano/node-code-sandbox-mcp

--- a/projects.yaml
+++ b/projects.yaml
@@ -516,6 +516,14 @@ projects:
       Kubernetes bulk port forwarding with service discovery, /etc/hosts
       management, traffic monitoring, and pod log streaming.
     category: cloud-platforms
+  - name: zopdev/mcp
+    github_id: zopdev/mcp
+    homepage: https://zop.dev/learn/mcp-server?utm_source=tolkonepiu-best-of-mcp-servers&utm_medium=listing&utm_campaign=mcp-directory
+    description: >-
+      Cloud cost, inventory and governance across AWS, Azure and GCP. 289 tools
+      (165 read, 124 write), read-only by default with optional scoped writes,
+      over a hosted remote streamable-HTTP endpoint.
+    category: cloud-platforms
   - name: alfonsograziano/node-code-sandbox-mcp
     github_id: alfonsograziano/node-code-sandbox-mcp
     description: >-

--- a/projects.yaml
+++ b/projects.yaml
@@ -521,7 +521,7 @@ projects:
     homepage: https://zop.dev/learn/mcp-server?utm_source=tolkonepiu-best-of-mcp-servers&utm_medium=listing&utm_campaign=mcp-directory
     description: >-
       Cloud cost and infrastructure governance across AWS, Azure, GCP,
-      Databricks and Snowflake. 289 tools (165 read, 124 write), read-only by
+      Databricks and Snowflake. 263 tools (155 read, 108 write), read-only by
       default with optional scoped writes, over a hosted remote
       streamable-HTTP endpoint.
     category: cloud-platforms


### PR DESCRIPTION
**ZopDev MCP**: cloud cost and infrastructure governance across AWS, Azure, GCP, Databricks and Snowflake. 263 tools (155 read, 108 write) covering cost, resources, schedules, recommendations, budgets, governance and diagnostics over a hosted remote MCP endpoint. Read-only by default, with optional scoped writes.

- server link — `https://api.zop.dev/mcp-server`
- learn doc — https://zop.dev/learn/mcp-server?utm_source=tolkonepiu-best-of-mcp-servers&utm_medium=listing&utm_campaign=mcp-directory
- claude learn — https://zop.dev/learn/how-to/set-up-zopnight-mcp-for-claude
- repo — https://github.com/zopdev/mcp (Apache-2.0)

---

Adds **zopdev/mcp** to `projects.yaml` under `cloud-platforms` — a hosted, remote MCP server for cloud cost and infrastructure governance across AWS, Azure, GCP, Databricks and Snowflake.

- 263 tools (155 read, 108 write), read-only by default with optional scoped writes
- Clouds: AWS, Azure and GCP, plus Databricks on all three and Snowflake with usage-based cost
- Transport: `streamable-http` (JSON-RPC 2.0 over HTTP POST)
- Auth: OAuth 2.1, or a personal access token for CI and non-browser clients
- Remote and hosted — nothing to install, build or run

`github_id` is set to the public Apache-2.0 repository so the entry can be ranked. Validated `projects.yaml` parses cleanly (407 projects).

This supersedes #353, which was withdrawn because the repository it referenced did not exist.
